### PR TITLE
Hide "Change email" button from Azure B2C reset password flow

### DIFF
--- a/webapp/public/auth/main.css
+++ b/webapp/public/auth/main.css
@@ -1,4 +1,15 @@
-.govuk-link,
+/**
+* Hide "Change email" button from Azure B2C flows
+*/
+.buttons button#emailVerificationControl_but_change_claims {
+  visibility: hidden;
+}
+.buttons button:hover#emailVerificationControl_but_change_claims {
+  visibility: hidden;
+}
+/*
+* End "Hide 'Change email' button from Azure B2C flow"
+ */
 a {
   font-family: GDS Transport, arial, sans-serif;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Azure B2C provides a buried option to change the user's email within
the reset password flow.  If a user goes to sign in, selects "Forgot my
password", and verifies their email address, they are given the option
to change their email address as well as reset their password.

If a user changes their email using this flow, unexpected results will
occur because the user's address in Azure B2C will not match the email
address in the Beacons database.

This commit uses CSS to visually hide the "Change email" button.  There
is not currently a better way to toggle this user action within Azure
B2C.  (See https://docs.microsoft.com/en-us/answers/questions/619255/setting-to-remove-the-39change-email39-button-in-s.html)

A permanent fix to this problem would be to wholly use Azure B2C as the
identity service for Beacons and not duplicate user data in two places.
This would require a re-write of the Webapp and parts of the Service.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated
