### PR TITLE
Copy to clipboard

### DIFF
--- a/backoffice/src/utils/writingStyle.tsx
+++ b/backoffice/src/utils/writingStyle.tsx
@@ -91,8 +91,6 @@ function lookupFieldName(fieldName: string): string {
 }
 
 export function formatForClipboard(entity: Record<any, any>): string {
-  console.dir(entity);
-
   const isArrayWithData = (value: any): boolean =>
     Array.isArray(value) && value.length > 0;
 

--- a/backoffice/src/utils/writingStyle.tsx
+++ b/backoffice/src/utils/writingStyle.tsx
@@ -80,9 +80,22 @@ export const formatFieldValue = (
   return <i>{Placeholders.NoData}</i>;
 };
 
+const fieldNameReplacements: Record<string, string> = {
+  fixedVhfRadioValue: "MMSI",
+};
+
+function lookupFieldName(fieldName: string): string {
+  return fieldNameReplacements.hasOwnProperty(fieldName)
+    ? fieldNameReplacements[fieldName]
+    : fieldName;
+}
+
 export function formatForClipboard(entity: Record<any, any>): string {
+  console.dir(entity);
+
   const isArrayWithData = (value: any): boolean =>
     Array.isArray(value) && value.length > 0;
+
   const isKeyValueObject = (value: any): boolean =>
     value != null &&
     value.constructor.name === "Object" &&
@@ -90,6 +103,8 @@ export function formatForClipboard(entity: Record<any, any>): string {
 
   return Object.entries(entity)
     .map(([key, value]) => {
+      key = lookupFieldName(key);
+
       if (isArrayWithData(value)) {
         return (
           `\n=====${key.toUpperCase()}=====\n` +

--- a/backoffice/src/views/SingleBeaconRecordView.tsx
+++ b/backoffice/src/views/SingleBeaconRecordView.tsx
@@ -2,11 +2,13 @@ import { Grid, Tab, Tabs } from "@mui/material";
 import { Theme } from "@mui/material/styles";
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
+import { CopyToClipboardButton } from "components/CopyToClipboardButton";
 import { IBeacon } from "entities/IBeacon";
 import { IUsesGateway } from "gateways/uses/IUsesGateway";
 import { OwnerPanel } from "panels/ownerPanel/OwnerPanel";
 import { UsesListPanel } from "panels/usesPanel/UsesListPanel";
 import React, { FunctionComponent, useEffect, useState } from "react";
+import { formatForClipboard } from "utils/writingStyle";
 import { PageContent } from "../components/layout/PageContent";
 import { PageHeader } from "../components/layout/PageHeader";
 import { TabPanel } from "../components/layout/TabPanel";
@@ -67,7 +69,7 @@ export const SingleBeaconRecordView: FunctionComponent<
     <div className={classes.root}>
       <PageHeader>
         Hex ID/UIN: {hexId}{" "}
-        {/* <CopyToClipboardButton text={formatForClipboard(beacon)} /> */}
+        <CopyToClipboardButton text={formatForClipboard(beacon)} />
       </PageHeader>
 
       <PageContent>

--- a/backoffice/src/views/SingleLegacyBeaconRecordView.tsx
+++ b/backoffice/src/views/SingleLegacyBeaconRecordView.tsx
@@ -2,12 +2,14 @@ import { Grid, Tab, Tabs } from "@mui/material";
 import { Theme } from "@mui/material/styles";
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
+import { CopyToClipboardButton } from "components/CopyToClipboardButton";
 import { ILegacyBeacon } from "entities/ILegacyBeacon";
 import { LegacyBeaconSummaryPanel } from "panels/legacyBeaconSummaryPanel/LegacyBeaconSummaryPanel";
 import { LegacyEmergencyContactPanel } from "panels/legacyEmergencyContactPanel/LegacyEmergencyContactPanel";
 import { LegacyOwnerPanel } from "panels/legacyOwnerPanel/LegacyOwnerPanel";
 import { LegacyUsesListPanel } from "panels/usesPanel/LegacyUsesListPanel";
 import React, { FunctionComponent, useEffect, useState } from "react";
+import { formatForClipboard } from "utils/writingStyle";
 import { PageContent } from "../components/layout/PageContent";
 import { PageHeader } from "../components/layout/PageHeader";
 import { TabPanel } from "../components/layout/TabPanel";
@@ -62,7 +64,7 @@ export const SingleLegacyBeaconRecordView: FunctionComponent<
     <div className={classes.root}>
       <PageHeader>
         Hex ID/UIN: {hexId}{" "}
-        {/* <CopyToClipboardButton text={formatForClipboard(beacon)} /> */}
+        <CopyToClipboardButton text={formatForClipboard(beacon)} />
       </PageHeader>
       <PageContent>
         <LegacyBeaconSummaryPanel legacyBeacon={beacon} />


### PR DESCRIPTION
## Context

The copy to clipboard changes needed to map all the fields properly. The MMSI field was showing in the copied text as having a different name.

## Changes in this pull request

- Added lookupFieldName() function in writingStyle.ts to change the fixedVhfRadioValue field to use the name MMSI
- Re-enabled the CopyToClipboard button in SingleBeaconRecordView

## Guidance to review

- Check my TypeScript

## Link to Trello card

https://trello.com/c/twjWBsjl/490-clipboard-as-a-sar-operator-when-a-beacon-is-activated-i-want-to-be-able-to-easily-copy-the-vital-information-all-from-the-back

## Things to check

- writingStyle.ts tests all still pass
