### PR TITLE
Service health check

### DIFF
--- a/webapp/src/components/PanelFailed.tsx
+++ b/webapp/src/components/PanelFailed.tsx
@@ -1,8 +1,6 @@
-import React, { ReactChild, ReactChildren } from "react";
+import React, { ReactNode } from "react";
 
-export const PanelFailed = (props: {
-  children: ReactChildren | ReactChild;
-}): JSX.Element => (
+export const PanelFailed = (props: { children: ReactNode }): JSX.Element => (
   <div
     className="govuk-error-summary"
     aria-labelledby="error-summary-title"


### PR DESCRIPTION
## Context

Cypress was breaking the build pipeline because a React type was wrong

## Changes in this pull request
- Updated the type of a prop for a component to ReactNode

