### PR TITLE
GovNotify text changes

### DIFF
--- a/webapp/src/components/Textarea.tsx
+++ b/webapp/src/components/Textarea.tsx
@@ -21,6 +21,7 @@ interface TextareaCharacterCountProps {
   label?: string;
   defaultValue?: string;
   hintText?: string;
+  boldText?: string;
   name?: string;
   rows?: number;
   htmlAttributes?: InputHTMLAttributes<Element>;
@@ -66,6 +67,7 @@ export const TextareaCharacterCount: FunctionComponent<
   label = null,
   defaultValue = "",
   hintText = null,
+  boldText = null,
   name = null,
   rows = 3,
   htmlAttributes = {},
@@ -81,6 +83,15 @@ export const TextareaCharacterCount: FunctionComponent<
     hintComponent = <FormHint forId={id}>{hintText}</FormHint>;
   }
 
+  let boldTextComponent: ReactNode;
+  if (boldText) {
+    boldTextComponent = (
+      <FormHint forId={id} className="govuk-!-font-weight-bold">
+        {boldText}
+      </FormHint>
+    );
+  }
+
   return (
     <div
       className="govuk-character-count"
@@ -90,6 +101,7 @@ export const TextareaCharacterCount: FunctionComponent<
       <FormGroup errorMessages={errorMessages}>
         {labelComponent}
         {hintComponent}
+        {boldTextComponent}
         <textarea
           className="govuk-textarea govuk-js-character-count"
           id={id}

--- a/webapp/src/pages/feedback/index.tsx
+++ b/webapp/src/pages/feedback/index.tsx
@@ -78,7 +78,8 @@ export const Feedback: FunctionComponent<DraftRegistrationPageProps> = ({
       <TextareaCharacterCount
         id="howCouldWeImproveThisService"
         label="How could we improve this service?"
-        hintText="Please provide a contact at the end, e.g. telephone or email address, if you would like the Beacon team to respond, as this isn’t automatically captured."
+        hintText="Please provide a contact at the end, e.g. telephone or email address, if you would like the Beacon team to respond."
+        boldText="Your telephone and email address are not automatically captured in this form."
         maxCharacters={1200}
         rows={4}
       />


### PR DESCRIPTION
Added nullable bold text prop to TextareaCharacterCount. Passing in additional text in bold

## Context

In the public facing Beacons app, we want to add more text to the GovNotify feedback form that appears at the end of the user journey to register a beacon. We want some of it to be emboldened.

## Changes in this pull request
- Addition of a new prop to TextareaCharacterCount component to pass in any additional text that should be bold


## Link to Trello card
https://trello.com/c/lFkyckfz/554-govnotify-text


