### PR TITLE
Azure Group assigning functionality

### DIFF
--- a/backoffice/src/index.scss
+++ b/backoffice/src/index.scss
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+.print-buttons {
+  display: inline;
+}

--- a/backoffice/src/lib/User.tsx
+++ b/backoffice/src/lib/User.tsx
@@ -19,6 +19,9 @@ export type UserAttributes = {
 export type Role =
   | "DEFAULT_ACCESS"
   | "ADD_BEACON_NOTES"
+  // is it UPDATE_RECORDS or UPDATE_BEACONS in Azure?
+  // if not created yet I would go with UPDATE_BEACONS because that's consistnet
+  // it's APPROLE_UPDATE_RECORDS in the Java
   | "UPDATE_RECORDS"
   | "DATA_EXPORTER"
   | "DELETE_BEACONS"

--- a/backoffice/src/lib/User.tsx
+++ b/backoffice/src/lib/User.tsx
@@ -19,9 +19,6 @@ export type UserAttributes = {
 export type Role =
   | "DEFAULT_ACCESS"
   | "ADD_BEACON_NOTES"
-  // is it UPDATE_RECORDS or UPDATE_BEACONS in Azure?
-  // if not created yet I would go with UPDATE_BEACONS because that's consistnet
-  // it's APPROLE_UPDATE_RECORDS in the Java
   | "UPDATE_RECORDS"
   | "DATA_EXPORTER"
   | "DELETE_BEACONS"

--- a/backoffice/src/panels/beaconSummaryPanel/BeaconSummaryPanel.test.tsx
+++ b/backoffice/src/panels/beaconSummaryPanel/BeaconSummaryPanel.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beaconFixture } from "../../fixtures/beacons.fixture";
 import { IBeaconsGateway } from "../../gateways/beacons/IBeaconsGateway";
-import { AuthProvider } from "components/auth/AuthProvider";
+import {
+  AuthContext,
+  AuthProvider,
+  IAuthContext,
+} from "components/auth/AuthProvider";
 import { Placeholders } from "../../utils/writingStyle";
 import { BeaconSummaryPanel } from "./BeaconSummaryPanel";
 
@@ -10,6 +14,7 @@ jest.mock("../../utils/logger");
 
 describe("BeaconSummaryPanel", () => {
   let beaconsGatewayDouble: IBeaconsGateway;
+  let authContext: IAuthContext;
 
   beforeEach(() => {
     beaconsGatewayDouble = {
@@ -19,14 +24,28 @@ describe("BeaconSummaryPanel", () => {
       updateBeacon: jest.fn(),
       deleteBeacon: jest.fn(),
     };
+    authContext = {
+      user: {
+        type: "loggedInUser",
+        attributes: {
+          username: "steve.stevington@mcga.gov.uk",
+          displayName: "Steve Stevington",
+          roles: ["UPDATE_RECORDS"],
+        },
+        apiAccessToken: "mockAccessTokenString",
+      },
+      logout: jest.fn(),
+    };
   });
 
   it("calls the injected BeaconsGateway", async () => {
     render(
-      <BeaconSummaryPanel
-        beaconsGateway={beaconsGatewayDouble}
-        beaconId={beaconFixture.id}
-      />
+      <AuthContext.Provider value={authContext}>
+        <BeaconSummaryPanel
+          beaconsGateway={beaconsGatewayDouble}
+          beaconId={beaconFixture.id}
+        />
+      </AuthContext.Provider>
     );
 
     await waitFor(() => {
@@ -40,10 +59,12 @@ describe("BeaconSummaryPanel", () => {
     });
     jest.spyOn(console, "error").mockImplementation(() => {}); // Avoid console error failing test
     render(
-      <BeaconSummaryPanel
-        beaconsGateway={beaconsGatewayDouble}
-        beaconId={"doesn't exist"}
-      />
+      <AuthContext.Provider value={authContext}>
+        <BeaconSummaryPanel
+          beaconsGateway={beaconsGatewayDouble}
+          beaconId={"doesn't exist"}
+        />
+      </AuthContext.Provider>
     );
 
     expect(await screen.findByRole("alert")).toBeVisible();
@@ -54,12 +75,12 @@ describe("BeaconSummaryPanel", () => {
 
   it("fetches beacon data on state change", async () => {
     render(
-      <AuthProvider>
+      <AuthContext.Provider value={authContext}>
         <BeaconSummaryPanel
           beaconsGateway={beaconsGatewayDouble}
           beaconId={beaconFixture.id}
         />
-      </AuthProvider>
+      </AuthContext.Provider>
     );
     expect(beaconsGatewayDouble.getBeacon).toHaveBeenCalledTimes(1);
 
@@ -72,5 +93,32 @@ describe("BeaconSummaryPanel", () => {
     });
     userEvent.click(cancelButton);
     expect(beaconsGatewayDouble.getBeacon).toHaveBeenCalledTimes(3);
+  });
+
+  it("expect edit button with UPDATE_RECORDS role", async () => {
+    let brtAuthContext: IAuthContext = {
+      user: {
+        type: "loggedInUser",
+        attributes: {
+          username: "steve.stevington@mcga.gov.uk",
+          displayName: "Steve Stevington (BRT)",
+          roles: ["UPDATE_RECORDS"],
+        },
+        apiAccessToken: "mockAccessTokenString",
+      },
+      logout: jest.fn(),
+    };
+
+    render(
+      <AuthContext.Provider value={brtAuthContext}>
+        <BeaconSummaryPanel
+          beaconsGateway={beaconsGatewayDouble}
+          beaconId={beaconFixture.id}
+        />
+      </AuthContext.Provider>
+    );
+    const editButton = await screen.findByText(/edit summary/i);
+
+    expect(editButton).toBeVisible();
   });
 });

--- a/backoffice/src/panels/beaconSummaryPanel/BeaconSummaryPanel.test.tsx
+++ b/backoffice/src/panels/beaconSummaryPanel/BeaconSummaryPanel.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beaconFixture } from "../../fixtures/beacons.fixture";
 import { IBeaconsGateway } from "../../gateways/beacons/IBeaconsGateway";
+import { AuthProvider } from "components/auth/AuthProvider";
 import { Placeholders } from "../../utils/writingStyle";
 import { BeaconSummaryPanel } from "./BeaconSummaryPanel";
 
@@ -53,10 +54,12 @@ describe("BeaconSummaryPanel", () => {
 
   it("fetches beacon data on state change", async () => {
     render(
-      <BeaconSummaryPanel
-        beaconsGateway={beaconsGatewayDouble}
-        beaconId={beaconFixture.id}
-      />
+      <AuthProvider>
+        <BeaconSummaryPanel
+          beaconsGateway={beaconsGatewayDouble}
+          beaconId={beaconFixture.id}
+        />
+      </AuthProvider>
     );
     expect(beaconsGatewayDouble.getBeacon).toHaveBeenCalledTimes(1);
 

--- a/backoffice/src/panels/beaconSummaryPanel/BeaconSummaryPanel.tsx
+++ b/backoffice/src/panels/beaconSummaryPanel/BeaconSummaryPanel.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardHeader } from "@mui/material";
+import { OnlyVisibleToUsersWith } from "components/auth/OnlyVisibleToUsersWith";
 import { FunctionComponent, useEffect, useState } from "react";
 import { EditPanelButton } from "../../components/dataPanel/EditPanelButton";
 import { ErrorState } from "../../components/dataPanel/PanelErrorState";
@@ -61,22 +62,24 @@ export const BeaconSummaryPanel: FunctionComponent<IBeaconSummaryProps> = ({
     switch (state) {
       case DataPanelStates.Viewing:
         return (
-          <>
+          <OnlyVisibleToUsersWith role={"UPDATE_RECORDS"}>
             <EditPanelButton
               onClick={() => setUserState(DataPanelStates.Editing)}
             >
               Edit summary
             </EditPanelButton>
             <BeaconSummaryViewing beacon={beacon} />
-          </>
+          </OnlyVisibleToUsersWith>
         );
       case DataPanelStates.Editing:
         return (
-          <BeaconSummaryEditing
-            beacon={beacon}
-            onSave={handleSave}
-            onCancel={() => setUserState(DataPanelStates.Viewing)}
-          />
+          <OnlyVisibleToUsersWith role={"UPDATE_RECORDS"}>
+            <BeaconSummaryEditing
+              beacon={beacon}
+              onSave={handleSave}
+              onCancel={() => setUserState(DataPanelStates.Viewing)}
+            />
+          </OnlyVisibleToUsersWith>
         );
       default:
         setError(true);

--- a/backoffice/src/panels/beaconSummaryPanel/BeaconSummaryPanel.tsx
+++ b/backoffice/src/panels/beaconSummaryPanel/BeaconSummaryPanel.tsx
@@ -32,6 +32,7 @@ export const BeaconSummaryPanel: FunctionComponent<IBeaconSummaryProps> = ({
   useEffect((): void => {
     const fetchBeacon = async (id: string) => {
       try {
+        setError(false);
         setLoading(true);
         const beacon = await beaconsGateway.getBeacon(id);
         setBeacon(beacon);
@@ -62,14 +63,17 @@ export const BeaconSummaryPanel: FunctionComponent<IBeaconSummaryProps> = ({
     switch (state) {
       case DataPanelStates.Viewing:
         return (
-          <OnlyVisibleToUsersWith role={"UPDATE_RECORDS"}>
-            <EditPanelButton
-              onClick={() => setUserState(DataPanelStates.Editing)}
-            >
-              Edit summary
-            </EditPanelButton>
+          <>
+            <OnlyVisibleToUsersWith role={"UPDATE_RECORDS"}>
+              <EditPanelButton
+                onClick={() => setUserState(DataPanelStates.Editing)}
+              >
+                Edit summary
+              </EditPanelButton>
+            </OnlyVisibleToUsersWith>
+
             <BeaconSummaryViewing beacon={beacon} />
-          </OnlyVisibleToUsersWith>
+          </>
         );
       case DataPanelStates.Editing:
         return (

--- a/backoffice/src/panels/notesPanel/NotesPanel.test.tsx
+++ b/backoffice/src/panels/notesPanel/NotesPanel.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { AuthProvider } from "components/auth/AuthProvider";
 import { INotesGateway } from "../../gateways/notes/INotesGateway";
 import { Placeholders } from "../../utils/writingStyle";
 import { NotesPanel } from "./NotesPanel";
@@ -42,7 +43,11 @@ describe("NotesPanel", () => {
   });
 
   it("fetches notes data on state change", async () => {
-    render(<NotesPanel notesGateway={notesGateway} beaconId={beaconId} />);
+    render(
+      <AuthProvider>
+        <NotesPanel notesGateway={notesGateway} beaconId={beaconId} />
+      </AuthProvider>
+    );
     expect(notesGateway.getNotes).toHaveBeenCalledTimes(1);
 
     const addNoteButton = await screen.findByText(/add a new note/i);

--- a/backoffice/src/panels/notesPanel/NotesPanel.test.tsx
+++ b/backoffice/src/panels/notesPanel/NotesPanel.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { AuthProvider } from "components/auth/AuthProvider";
+import {
+  AuthContext,
+  AuthProvider,
+  IAuthContext,
+} from "components/auth/AuthProvider";
 import { INotesGateway } from "../../gateways/notes/INotesGateway";
 import { Placeholders } from "../../utils/writingStyle";
 import { NotesPanel } from "./NotesPanel";
@@ -10,6 +14,7 @@ jest.mock("../../utils/logger");
 describe("NotesPanel", () => {
   let notesGateway: INotesGateway;
   let beaconId: string;
+  let authContext: IAuthContext;
 
   beforeEach(() => {
     notesGateway = {
@@ -17,6 +22,19 @@ describe("NotesPanel", () => {
       createNote: jest.fn(),
     };
     beaconId = "12345";
+
+    authContext = {
+      user: {
+        type: "loggedInUser",
+        attributes: {
+          username: "steve.stevington@mcga.gov.uk",
+          displayName: "Steve Stevington",
+          roles: ["ADD_BEACON_NOTES"],
+        },
+        apiAccessToken: "mockAccessTokenString",
+      },
+      logout: jest.fn(),
+    };
   });
 
   it("calls the injected NotesGateway", async () => {
@@ -44,9 +62,9 @@ describe("NotesPanel", () => {
 
   it("fetches notes data on state change", async () => {
     render(
-      <AuthProvider>
+      <AuthContext.Provider value={authContext}>
         <NotesPanel notesGateway={notesGateway} beaconId={beaconId} />
-      </AuthProvider>
+      </AuthContext.Provider>
     );
     expect(notesGateway.getNotes).toHaveBeenCalledTimes(1);
 

--- a/backoffice/src/panels/notesPanel/NotesPanel.tsx
+++ b/backoffice/src/panels/notesPanel/NotesPanel.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent } from "@mui/material";
+import { OnlyVisibleToUsersWith } from "components/auth/OnlyVisibleToUsersWith";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { PanelButton } from "../../components/dataPanel/EditPanelButton";
 import { ErrorState } from "../../components/dataPanel/PanelErrorState";
@@ -58,19 +59,21 @@ export const NotesPanel: FunctionComponent<NotesPanelProps> = ({
     switch (state) {
       case DataPanelStates.Viewing:
         return (
-          <>
+          <OnlyVisibleToUsersWith role={"ADD_BEACON_NOTES"}>
             <PanelButton onClick={() => setUserState(DataPanelStates.Editing)}>
               Add a new note
             </PanelButton>
             <NotesViewing notes={notes} />
-          </>
+          </OnlyVisibleToUsersWith>
         );
       case DataPanelStates.Editing:
         return (
-          <NotesEditing
-            onSave={handleSave}
-            onCancel={() => setUserState(DataPanelStates.Viewing)}
-          />
+          <OnlyVisibleToUsersWith role={"ADD_BEACON_NOTES"}>
+            <NotesEditing
+              onSave={handleSave}
+              onCancel={() => setUserState(DataPanelStates.Viewing)}
+            />
+          </OnlyVisibleToUsersWith>
         );
       default:
         setError(true);

--- a/service/src/main/java/uk/gov/mca/beacons/api/auth/gateway/AuthGatewayImpl.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/auth/gateway/AuthGatewayImpl.java
@@ -67,5 +67,6 @@ public class AuthGatewayImpl implements AuthGateway {
     APPROLE_DATA_EXPORTER,
     APPROLE_DELETE_BEACONS,
     APPROLE_ADMIN_EXPORT,
+    APPROLE_ADD_BEACON_NOTES,
   }
 }

--- a/service/src/main/java/uk/gov/mca/beacons/api/export/ExportController.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/export/ExportController.java
@@ -73,6 +73,7 @@ class ExportController {
     return new ResponseEntity<>(resource, headers, HttpStatus.OK);
   }
 
+  @PreAuthorize("hasAuthority('APPROLE_ADMIN_EXPORT')")
   @GetMapping(value = "/label/{uuid}")
   public ResponseEntity<byte[]> getLabelByBeaconId(
     @PathVariable("uuid") UUID rawBeaconId
@@ -87,6 +88,7 @@ class ExportController {
       .body(file);
   }
 
+  @PreAuthorize("hasAuthority('APPROLE_ADMIN_EXPORT')")
   @PostMapping(value = "/labels")
   public ResponseEntity<byte[]> getLabelsByBeaconIds(
     @RequestBody @Valid List<UUID> rawBeaconIds
@@ -105,6 +107,7 @@ class ExportController {
       .body(file);
   }
 
+  @PreAuthorize("hasAuthority('APPROLE_ADMIN_EXPORT')")
   @PostMapping(value = "/beacons/data")
   public ResponseEntity<List<BeaconExportDTO>> getBeacons(
     @RequestBody @Valid List<UUID> rawBeaconIds
@@ -121,6 +124,7 @@ class ExportController {
       .body(dataList);
   }
 
+  @PreAuthorize("hasAuthority('APPROLE_ADMIN_EXPORT')")
   @GetMapping(value = "/certificate/data/{uuid}")
   public ResponseEntity<BeaconExportDTO> getCertificateDataByBeaconId(
     @PathVariable("uuid") UUID rawBeaconId
@@ -136,6 +140,7 @@ class ExportController {
       .body(data);
   }
 
+  @PreAuthorize("hasAuthority('APPROLE_ADMIN_EXPORT')")
   @PostMapping(value = "/certificates/data")
   public ResponseEntity<List<BeaconExportDTO>> getCertificatesDataByBeaconIds(
     @RequestBody @Valid List<UUID> rawBeaconIds
@@ -152,6 +157,7 @@ class ExportController {
       .body(dataList);
   }
 
+  @PreAuthorize("hasAuthority('APPROLE_ADMIN_EXPORT')")
   @GetMapping(value = "/letter/data/{uuid}")
   public ResponseEntity<BeaconExportDTO> getLetterDataByBeaconId(
     @PathVariable("uuid") UUID rawBeaconId
@@ -167,6 +173,7 @@ class ExportController {
       .body(data);
   }
 
+  @PreAuthorize("hasAuthority('APPROLE_ADMIN_EXPORT')")
   @PostMapping(value = "/letters/data")
   public ResponseEntity<List<BeaconExportDTO>> postRetrieveLettersByBeaconIds(
     @RequestBody @Valid List<UUID> ids
@@ -181,23 +188,5 @@ class ExportController {
       .ok()
       .contentType(MediaType.APPLICATION_JSON)
       .body(dataList);
-  }
-
-  private ResponseEntity<byte[]> servePdf(byte[] file, String filename) {
-    HttpHeaders headers = new HttpHeaders();
-    headers.set(
-      HttpHeaders.CONTENT_DISPOSITION,
-      "attachment; filename=" + filename
-    );
-    headers.set(
-      HttpHeaders.CACHE_CONTROL,
-      "no-cache, no-store, must-revalidate"
-    );
-    //    headers.add("Access-Control-Allow-Origin", "*");
-    return ResponseEntity
-      .ok()
-      .contentType(MediaType.APPLICATION_PDF)
-      .headers(headers)
-      .body(file);
   }
 }

--- a/service/src/main/java/uk/gov/mca/beacons/api/note/rest/NoteController.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/note/rest/NoteController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.mca.beacons.api.auth.application.GetUserService;
 import uk.gov.mca.beacons.api.beacon.domain.BeaconId;
@@ -36,6 +37,7 @@ public class NoteController {
   }
 
   @PostMapping
+  @PreAuthorize("hasAuthority('APPROLE_ADD_BEACON_NOTES')")
   @ResponseStatus(HttpStatus.CREATED)
   public WrapperDTO<NoteDTO> createNote(
     @RequestBody @Valid WrapperDTO<CreateNoteDTO> dto


### PR DESCRIPTION
Added missing Azure AD roles to Java code. Applied roles to relevant endpoints. Applied roles to React app

## Context
We want to only authorise select groups of users to do certain things in the Beacons Backoffice app. E.g:
- SAR operators should not be able to edit or delete a beacon record
- Only those with the ADD_BEACON_NOTES role should be able to add notes about a beacon

## Changes in this pull request
- Addition of some missing roles that were present in Azure but missing from the Java code
- Application of all the roles to their relevant features


## Link to Trello card
https://trello.com/c/qtWu7BKZ/603-azure-group-assigning-functionality


