### PR TITLE
642 bug migrated deleted status

### DIFF
--- a/service/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeacon.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeacon.java
@@ -45,7 +45,6 @@ public class LegacyBeacon extends BaseAggregateRoot<LegacyBeaconId> {
   private String ownerEmail;
 
   @Setter
-  @Getter
   private String beaconStatus;
 
   @Setter
@@ -75,6 +74,7 @@ public class LegacyBeacon extends BaseAggregateRoot<LegacyBeaconId> {
   @NotNull
   private OffsetDateTime lastModifiedDate;
 
+  // delete story
   public boolean isClaimed() {
     if (actions == null) {
       return false;
@@ -91,6 +91,26 @@ public class LegacyBeacon extends BaseAggregateRoot<LegacyBeaconId> {
       this.registerEvent(new LegacyBeaconClaimed(this));
       this.setBeaconStatus("CLAIMED");
     }
+  }
+
+  // before delete story
+
+  public void claim() {
+    initActions();
+    if (!isClaimed()) {
+      LegacyBeaconClaimAction claimAction = new LegacyBeaconClaimAction();
+      actions.add(claimAction);
+      this.registerEvent(new LegacyBeaconClaimed(this));
+    }
+  }
+
+  // reinstate this and remove the default getter from beaconStatus
+  public String getBeaconStatus() {
+    if (isClaimed()) {
+      return "CLAIMED";
+    }
+
+    return beaconStatus;
   }
 
   public void softDelete() {

--- a/service/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeacon.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeacon.java
@@ -45,7 +45,6 @@ public class LegacyBeacon extends BaseAggregateRoot<LegacyBeaconId> {
   private String ownerEmail;
 
   @Setter
-  @Getter
   private String beaconStatus;
 
   @Setter
@@ -89,7 +88,6 @@ public class LegacyBeacon extends BaseAggregateRoot<LegacyBeaconId> {
       LegacyBeaconClaimAction claimAction = new LegacyBeaconClaimAction();
       actions.add(claimAction);
       this.registerEvent(new LegacyBeaconClaimed(this));
-      this.setBeaconStatus("CLAIMED");
     }
   }
 

--- a/service/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeacon.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeacon.java
@@ -45,6 +45,7 @@ public class LegacyBeacon extends BaseAggregateRoot<LegacyBeaconId> {
   private String ownerEmail;
 
   @Setter
+  @Getter
   private String beaconStatus;
 
   @Setter
@@ -74,7 +75,6 @@ public class LegacyBeacon extends BaseAggregateRoot<LegacyBeaconId> {
   @NotNull
   private OffsetDateTime lastModifiedDate;
 
-  // delete story
   public boolean isClaimed() {
     if (actions == null) {
       return false;
@@ -93,18 +93,6 @@ public class LegacyBeacon extends BaseAggregateRoot<LegacyBeaconId> {
     }
   }
 
-  // before delete story
-
-  public void claim() {
-    initActions();
-    if (!isClaimed()) {
-      LegacyBeaconClaimAction claimAction = new LegacyBeaconClaimAction();
-      actions.add(claimAction);
-      this.registerEvent(new LegacyBeaconClaimed(this));
-    }
-  }
-
-  // reinstate this and remove the default getter from beaconStatus
   public String getBeaconStatus() {
     if (isClaimed()) {
       return "CLAIMED";

--- a/service/src/test/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeaconTest.java
+++ b/service/src/test/java/uk/gov/mca/beacons/api/legacybeacon/domain/LegacyBeaconTest.java
@@ -1,0 +1,56 @@
+package uk.gov.mca.beacons.api.legacybeacon.domain;
+
+import static uk.gov.mca.beacons.api.legacybeacon.LegacyBeaconTestUtils.initLegacyBeacon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.mca.beacons.api.legacybeacon.LegacyBeaconTestUtils;
+
+public class LegacyBeaconTest {
+
+  @Test
+  void getBeaconStatus_whenTheInitialBeaconStatusIsMigratedAndTheBeaconHasBeenClaimed_shouldReturnCLAIMED()
+    throws Exception {
+    LegacyBeacon legacyBeacon = LegacyBeaconTestUtils.initLegacyBeacon();
+    legacyBeacon.claim();
+
+    String beaconStatus = legacyBeacon.getBeaconStatus();
+
+    assert beaconStatus == "CLAIMED";
+  }
+
+  @Test
+  void getBeaconStatus_whenTheInitialBeaconStatusIsClaimedAndTheBeaconHasBeenClaimed_shouldReturnCLAIMED()
+    throws Exception {
+    LegacyBeacon legacyBeacon = LegacyBeaconTestUtils.initLegacyBeacon();
+    legacyBeacon.setBeaconStatus("CLAIMED");
+    legacyBeacon.claim();
+
+    String beaconStatus = legacyBeacon.getBeaconStatus();
+
+    assert beaconStatus == "CLAIMED";
+  }
+
+  @Test
+  void getBeaconStatus_whenTheInitialBeaconStatusIsMigratedAndTheBeaconHasBeenSoftDeleted_shouldReturnDELETED()
+    throws Exception {
+    LegacyBeacon legacyBeacon = LegacyBeaconTestUtils.initLegacyBeacon();
+    legacyBeacon.softDelete();
+
+    String beaconStatus = legacyBeacon.getBeaconStatus();
+
+    assert beaconStatus == "DELETED";
+  }
+
+  @Test
+  void getBeaconStatus_whenTheInitialBeaconStatusIsMigratedAndNoActionsHaveHappened_shouldReturnMIGRATED()
+    throws Exception {
+    LegacyBeacon legacyBeacon = LegacyBeaconTestUtils.initLegacyBeacon();
+
+    String beaconStatus = legacyBeacon.getBeaconStatus();
+
+    assert beaconStatus == "MIGRATED";
+  }
+}


### PR DESCRIPTION
## Context

A bug emerged in production: claimed legacy beacons with a beaconStatus of MIGRATED in the DB were showing incorrectly as MIGRATED in the backoffice app. This was because the getStatus() logic was removed during the delete beacon story. We have reinstated this now.

## Changes in this pull request
- Added unit tests for LegacyBeacon domain model
- Removed line in LegacyBeacon.claim() that changes the beaconStatus to CLAIMED in the DB
- Reinstated the custom getBeaconStatus() method that relies on isClaimed() to determine if a beacon has been claimed


## Link to Trello card
[bug card](https://trello.com/c/h1ryGHoQ/642-p2-migrated-deleted-status-in-back-end-records-are-erroneous)
