### PR TITLE
Hide backup contingency button entirely

### DIFF
--- a/backoffice/src/components/layout/SettingsDrawer.tsx
+++ b/backoffice/src/components/layout/SettingsDrawer.tsx
@@ -125,21 +125,23 @@ export const SettingsDrawer: React.FunctionComponent<ISettingsDrawerProps> = ({
             />
           </OnlyVisibleToUsersWith>
           <OnlyVisibleToUsersWith role={"ADMIN_EXPORT"}>
-            <Typography
-              gutterBottom={true}
-              component={"p"}
-              variant={"subtitle2"}
-              id="feedback"
-            >
-              Backup
-            </Typography>
-            <AuthenticatedDownloadButton
-              label="Backup export"
-              url={`${applicationConfig.apiUrl}/export/xlsx/backup`}
-              isFullWidth={true}
-              downloadStarted={handleDownloadStarted}
-              downloadComplete={handleDownloadComplete}
-            />
+            <div className="hidden-button">
+              <Typography
+                gutterBottom={true}
+                component={"p"}
+                variant={"subtitle2"}
+                id="feedback"
+              >
+                Backup
+              </Typography>
+              <AuthenticatedDownloadButton
+                label="Backup export"
+                url={`${applicationConfig.apiUrl}/export/xlsx/backup`}
+                isFullWidth={true}
+                downloadStarted={handleDownloadStarted}
+                downloadComplete={handleDownloadComplete}
+              />
+            </div>
             <Typography
               gutterBottom={true}
               component={"p"}

--- a/backoffice/src/index.scss
+++ b/backoffice/src/index.scss
@@ -20,3 +20,7 @@ code {
   margin-left: 120px;
   margin-top: 20px;
 }
+
+.hidden-button {
+  display: none;
+}


### PR DESCRIPTION
## Context
Pull request #377 from mcagov/sar_backup_export caused the API to break in production. I reverted that merge from main and then went back to the sar_backup_export branch, creating a new one off it (this one) with the addition of a commit that hides the backup contingency button. 

## Changes in this pull request

We want to keep the backup contingency code but just hide the button from production, so nobody (not even the small group of ADMIN_EXPORT users) can click it and accidentally break the API.