### PR TITLE
Hide backup contingency button entirely

### DIFF
--- a/backoffice/src/components/layout/SettingsDrawer.tsx
+++ b/backoffice/src/components/layout/SettingsDrawer.tsx
@@ -125,21 +125,23 @@ export const SettingsDrawer: React.FunctionComponent<ISettingsDrawerProps> = ({
             />
           </OnlyVisibleToUsersWith>
           <OnlyVisibleToUsersWith role={"ADMIN_EXPORT"}>
-            <Typography
-              gutterBottom={true}
-              component={"p"}
-              variant={"subtitle2"}
-              id="feedback"
-            >
-              Backup
-            </Typography>
-            <AuthenticatedDownloadButton
-              label="Backup export"
-              url={`${applicationConfig.apiUrl}/export/xlsx/backup`}
-              isFullWidth={true}
-              downloadStarted={handleDownloadStarted}
-              downloadComplete={handleDownloadComplete}
-            />
+            <div className="hidden-button">
+              <Typography
+                gutterBottom={true}
+                component={"p"}
+                variant={"subtitle2"}
+                id="feedback"
+              >
+                Backup
+              </Typography>
+              <AuthenticatedDownloadButton
+                label="Backup export"
+                url={`${applicationConfig.apiUrl}/export/xlsx/backup`}
+                isFullWidth={true}
+                downloadStarted={handleDownloadStarted}
+                downloadComplete={handleDownloadComplete}
+              />
+            </div>
             <Typography
               gutterBottom={true}
               component={"p"}

--- a/backoffice/src/index.scss
+++ b/backoffice/src/index.scss
@@ -20,3 +20,7 @@ code {
   margin-left: 120px;
   margin-top: 20px;
 }
+
+.hidden-button {
+  display: none;
+}


### PR DESCRIPTION
## Context

- We made a copy of main
- We rolled this back to  79758c4e which was the merging of the sar backup export PR #377

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated
