### PR TITLE
change on-push to npm install from npm ci

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: "16.17.0"
       - name: Prettier check
         run: |
-          npm ci
+          npm install
           npm run format:check
 
   test_webapp:


### PR DESCRIPTION
## Context

Fix the install issue for npm within the on-push github action

## Changes in this pull request

Altered the way node manages the installation within the on-push github action

