### PR TITLE
add additional npm installs for broken actions

### DIFF
--- a/.github/workflows/test-webapp.yml
+++ b/.github/workflows/test-webapp.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: "16.17.0"
       - name: Install npm dependencies
-        run: npm ci
+        run: npm install
         env:
           CYPRESS_INSTALL_BINARY: 0
       - name: Code linting
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: "16.17.0"
       - name: Install npm dependencies
-        run: npm ci
+        run: npm install
         env:
           CYPRESS_INSTALL_BINARY: 0
       - name: Run tests
@@ -69,7 +69,7 @@ jobs:
         with:
           node-version: "16.17.0"
       - name: Install npm dependencies
-        run: npm ci
+        run: npm install
         env:
           CYPRESS_INSTALL_BINARY: 0
       - name: Copy env vars


### PR DESCRIPTION
## Context

A few more npm installs required to make the changes to the tests, that will enable the dependencies to work. 
## Changes in this pull request

Chnage `npm ci` to `npm install` within the test-webapp github actions.
## Guidance to review

