### PR TITLE
change node version in webapp docker to more precise 16.17

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,5 +1,5 @@
 # Base Docker image for multi-stage build
-FROM node:16-alpine AS base
+FROM node:16.17 AS base
 
 WORKDIR /usr/app
 
@@ -18,7 +18,7 @@ FROM base AS production-deps
 RUN npm install --production
 
 # NextJS production application
-FROM node:16-alpine AS nextjs-app
+FROM node:16.17-alpine AS nextjs-app
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Context

Webapp wouldn't build without the node being 16.17
## Changes in this pull request

Webapp containers changed to 16.17-alpine from 16

