### PR TITLE
Validate draft uses before submission

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -14,7 +14,7 @@ node_modules/
 .idea/
 .eslintcache
 .env
-.env
+.env.local
 
 # Cypress
 screenshots

--- a/webapp/src/lib/helpers/isValidUse.ts
+++ b/webapp/src/lib/helpers/isValidUse.ts
@@ -1,0 +1,27 @@
+import { DraftBeaconUse } from "../../entities/DraftBeaconUse";
+
+export const isValidUse = (use: DraftBeaconUse): boolean => {
+  const useProperties = Object.keys(use);
+
+  if (!useProperties.includes("environment")) return false;
+  if (!useProperties.includes("activity")) return false;
+  if (!useProperties.includes("moreDetails")) return false;
+
+  if (use["activity"] === "OTHER" && use["environment"] !== "LAND")
+    return useProperties.includes("otherActivityText");
+  if (use["environment"] === "MARITIME" || use["environment"] === "AVIATION")
+    return useProperties.includes("purpose");
+
+  if (use["environment"] === "LAND" && use["activity"] === "WORKING_REMOTELY")
+    return useProperties.includes("workingRemotelyLocation");
+  if (use["environment"] === "LAND" && use["activity"] === "WINDFARM")
+    return useProperties.includes("windfarmLocation");
+  if (use["environment"] === "LAND" && use["activity"] === "OTHER") {
+    return (
+      useProperties.includes("otherActivityText") &&
+      useProperties.includes("otherActivityLocation")
+    );
+  }
+
+  return true;
+};

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/about-the-aircraft.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/about-the-aircraft.tsx
@@ -58,12 +58,6 @@ const AboutTheAircraft: FunctionComponent<DraftBeaconUsePageProps> = ({
 
   return (
     <BeaconsForm
-      previousPageUrl={UrlBuilder.buildUseUrl(
-        Actions.update,
-        UsePages.activity,
-        draftRegistration.id,
-        useId
-      )}
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
       formErrors={form.errorSummary}

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/about-the-vessel.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/about-the-vessel.tsx
@@ -60,12 +60,6 @@ const AboutTheVessel: FunctionComponent<DraftBeaconUsePageProps> = ({
 
   return (
     <BeaconsForm
-      previousPageUrl={UrlBuilder.buildUseUrl(
-        Actions.update,
-        UsePages.activity,
-        draftRegistration.id,
-        useId
-      )}
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
       formErrors={form.errorSummary}

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/activity.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/activity.tsx
@@ -89,21 +89,6 @@ const ActivityPage: FunctionComponent<ActivityPageProps> = ({
 
   return (
     <BeaconsForm
-      previousPageUrl={
-        environment === Environment.LAND
-          ? UrlBuilder.buildUseUrl(
-              Actions.update,
-              UsePages.environment,
-              draftRegistration.id,
-              useId
-            )
-          : UrlBuilder.buildUseUrl(
-              Actions.update,
-              UsePages.purpose,
-              draftRegistration.id,
-              useId
-            )
-      }
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
       formErrors={form.errorSummary}

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/aircraft-communications.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/aircraft-communications.tsx
@@ -58,12 +58,6 @@ const AircraftCommunications: FunctionComponent<DraftBeaconUsePageProps> = ({
 
   return (
     <BeaconsForm
-      previousPageUrl={UrlBuilder.buildUseUrl(
-        Actions.update,
-        UsePages.aboutTheAircraft,
-        draftRegistration.id,
-        useId
-      )}
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
       formErrors={form.errorSummary}

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/environment.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/environment.tsx
@@ -64,10 +64,6 @@ const UpdateBeaconUsePage: FunctionComponent<DraftBeaconUsePageProps> = ({
   return (
     <BeaconsForm
       formErrors={form.errorSummary}
-      previousPageUrl={UrlBuilder.buildUseSummaryUrl(
-        Actions.update,
-        draftRegistration.id
-      )}
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
     >

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/land-communications.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/land-communications.tsx
@@ -71,12 +71,6 @@ const LandCommunications: FunctionComponent<DraftBeaconUsePageProps> = ({
   return (
     <BeaconsForm
       pageHeading={pageHeading}
-      previousPageUrl={UrlBuilder.buildUseUrl(
-        Actions.update,
-        UsePages.activity,
-        draftRegistration.id,
-        useId
-      )}
       formErrors={form.errorSummary}
       showCookieBanner={showCookieBanner}
     >

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/more-details.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/more-details.tsx
@@ -72,12 +72,6 @@ const MoreDetails: FunctionComponent<MoreDetailsPageProps> = ({
 
   return (
     <BeaconsForm
-      previousPageUrl={UrlBuilder.buildUseUrl(
-        Actions.update,
-        previousPageUrlMap[environment],
-        draftRegistration.id,
-        useId
-      )}
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
       formErrors={form.errorSummary}

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/purpose.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/purpose.tsx
@@ -59,12 +59,6 @@ const PurposePage: FunctionComponent<PurposeFormProps> = ({
   return (
     <BeaconsForm
       formErrors={form.errorSummary}
-      previousPageUrl={UrlBuilder.buildUseUrl(
-        Actions.update,
-        UsePages.environment,
-        draftRegistration.id,
-        useId
-      )}
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
     >

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/vessel-communications.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/[useId]/vessel-communications.tsx
@@ -74,12 +74,6 @@ const VesselCommunications: FunctionComponent<DraftBeaconUsePageProps> = ({
 
   return (
     <BeaconsForm
-      previousPageUrl={UrlBuilder.buildUseUrl(
-        Actions.update,
-        UsePages.aboutTheVessel,
-        draftRegistration.id,
-        useId
-      )}
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
       formErrors={form.errorSummary}

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/index.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/uses/index.tsx
@@ -105,11 +105,15 @@ const AdditionalBeaconUse: FunctionComponent<UseSummaryProps> = ({
                           draftRegistration.id,
                           index.toString()
                         )}
-                        deleteUri={confirmBeforeDelete(
-                          use,
-                          index,
-                          draftRegistration.id
-                        )}
+                        deleteUri={
+                          draftRegistration.uses.length > 1
+                            ? confirmBeforeDelete(
+                                use,
+                                index,
+                                draftRegistration.id
+                              )
+                            : undefined
+                        }
                         makeMainUseUri={
                           ActionURLs.mainCachedUseMain +
                           queryParams({

--- a/webapp/test/lib/helpers/isValidUse.test.ts
+++ b/webapp/test/lib/helpers/isValidUse.test.ts
@@ -1,0 +1,263 @@
+import { isValidUse } from "../../../src/lib/helpers/isValidUse";
+import { DraftBeaconUse } from "../../../src/entities/DraftBeaconUse";
+
+describe("isValidUse", () => {
+  it("returns true for a valid beacon", () => {
+    const maritimeInput: DraftBeaconUse = {
+      environment: "MARITIME",
+      purpose: "COMMERCIAL",
+      activity: "FISHING",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const aviationInput: DraftBeaconUse = {
+      environment: "AVIATION",
+      purpose: "COMMERCIAL",
+      activity: "JET",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const landInput: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "CYCLING",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const maritimeResponse = isValidUse(maritimeInput);
+    const aviationResponse = isValidUse(aviationInput);
+    const landResponse = isValidUse(landInput);
+
+    expect(maritimeResponse).toBeTruthy();
+    expect(aviationResponse).toBeTruthy();
+    expect(landResponse).toBeTruthy();
+  });
+
+  it("returns false for an invalid beacon", () => {
+    const maritimeInput: DraftBeaconUse = {
+      environment: "MARITIME",
+      activity: "FISHING",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const aviationInput: DraftBeaconUse = {
+      environment: "AVIATION",
+      activity: "JET",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const landInput: DraftBeaconUse = {
+      environment: "LAND",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const emptyInput: DraftBeaconUse = {
+      mainUse: true,
+    };
+
+    const maritimeResponse = isValidUse(maritimeInput);
+    const aviationResponse = isValidUse(aviationInput);
+    const landResponse = isValidUse(landInput);
+    const emptyResponse = isValidUse(landInput);
+
+    expect(maritimeResponse).toBeFalsy();
+    expect(aviationResponse).toBeFalsy();
+    expect(landResponse).toBeFalsy();
+    expect(emptyResponse).toBeFalsy();
+  });
+
+  it("returns false for a beacon missing moreDetails property", () => {
+    const maritimeInput: DraftBeaconUse = {
+      environment: "MARITIME",
+      purpose: "COMMERCIAL",
+      activity: "FISHING",
+      mainUse: true,
+    };
+
+    const aviationInput: DraftBeaconUse = {
+      environment: "AVIATION",
+      purpose: "COMMERCIAL",
+      activity: "JET",
+      mainUse: true,
+    };
+
+    const landInput: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "CYCLING",
+      mainUse: true,
+    };
+
+    const maritimeResponse = isValidUse(maritimeInput);
+    const aviationResponse = isValidUse(aviationInput);
+    const landResponse = isValidUse(landInput);
+
+    expect(maritimeResponse).toBeFalsy();
+    expect(aviationResponse).toBeFalsy();
+    expect(landResponse).toBeFalsy();
+  });
+
+  it("returns true for a valid land beacon used at a wind farm", () => {
+    const input: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "WINDFARM",
+      windfarmLocation: "Devon",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const response = isValidUse(input);
+
+    expect(response).toBeTruthy();
+  });
+
+  it("returns false for an invalid land beacon used at a wind farm missing windfarmLocation property", () => {
+    const input: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "WINDFARM",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const response = isValidUse(input);
+
+    expect(response).toBeFalsy();
+  });
+
+  it("returns true for a valid land beacon used for remote work", () => {
+    const input: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "WORKING_REMOTELY",
+      workingRemotelyLocation: "Devon",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const response = isValidUse(input);
+
+    expect(response).toBeTruthy();
+  });
+
+  it("returns false for an invalid land beacon used for remote work missing workingRemotelyLocation property", () => {
+    const input: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "WORKING_REMOTELY",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const response = isValidUse(input);
+
+    expect(response).toBeFalsy();
+  });
+
+  it("returns true for a valid land beacon with other activity", () => {
+    const input: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "OTHER",
+      otherActivityText: "Other description",
+      otherActivityLocation: "Devon",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const response = isValidUse(input);
+
+    expect(response).toBeTruthy();
+  });
+
+  it("returns false for an invalid land beacon with other activity missing otherActivityText and otherActivityLocation properties", () => {
+    const input: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "OTHER",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const response = isValidUse(input);
+
+    expect(response).toBeFalsy();
+  });
+
+  it("returns false for an invalid land beacon with other activity and missing otherActivityText property", () => {
+    const input: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "OTHER",
+      moreDetails: "More info",
+      otherActivityLocation: "Devon",
+      mainUse: true,
+    };
+
+    const response = isValidUse(input);
+
+    expect(response).toBeFalsy();
+  });
+
+  it("returns false for an invalid land beacon with other activity and missing otherActivityLocation property", () => {
+    const input: DraftBeaconUse = {
+      environment: "LAND",
+      activity: "OTHER",
+      moreDetails: "More info",
+      otherActivityText: "Other description",
+      mainUse: true,
+    };
+
+    const response = isValidUse(input);
+
+    expect(response).toBeFalsy();
+  });
+
+  it("returns true for valid maritime and aviation beacons with other activity", () => {
+    const maritimeInput: DraftBeaconUse = {
+      environment: "MARITIME",
+      purpose: "COMMERCIAL",
+      activity: "OTHER",
+      otherActivityText: "Info",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const aviationInput: DraftBeaconUse = {
+      environment: "AVIATION",
+      purpose: "COMMERCIAL",
+      activity: "OTHER",
+      otherActivityText: "Info",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const maritimeResponse = isValidUse(maritimeInput);
+    const aviationResponse = isValidUse(aviationInput);
+
+    expect(maritimeResponse).toBeTruthy();
+    expect(aviationResponse).toBeTruthy();
+  });
+
+  it("returns false for invalid maritime and aviation beacons with other activity missing otherActivityText property", () => {
+    const maritimeInput: DraftBeaconUse = {
+      environment: "MARITIME",
+      activity: "OTHER",
+      purpose: "COMMERCIAL",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const aviationInput: DraftBeaconUse = {
+      environment: "AVIATION",
+      activity: "OTHER",
+      purpose: "COMMERCIAL",
+      moreDetails: "More info",
+      mainUse: true,
+    };
+
+    const maritimeResponse = isValidUse(maritimeInput);
+    const aviationResponse = isValidUse(aviationInput);
+
+    expect(maritimeResponse).toBeFalsy();
+    expect(aviationResponse).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Context

This change is being made to prevent users from creating invalid beacon uses. These cause a 400 status response from the backend or invalid uses being saved to the database.

## Changes in this pull request

[Fixed webapp .gitignore](https://github.com/mcagov/beacons/commit/535faf93c2ff61e9754fc2e6d3ced3779e650c42)
[Tests for isValidUse helper function](https://github.com/mcagov/beacons/commit/4bdec3ceebea1d2384173ce4b79b901c000f91a4)
[Helper method for DraftBeaconUse validation. Tests passing](https://github.com/mcagov/beacons/commit/f56d36609af8551d863683611796fcc9ae4a420f)
[Remove invalid beacon uses from cache on RegistrationSummaryPage.](https://github.com/mcagov/beacons/commit/76fe881748a41ef633b3c26c1618951e5742fe5f)
[Removed back link from add/update use flow](https://github.com/mcagov/beacons/commit/1e1affa0a3f155209c26f1fb95eb7f9d176a2bd7)
