### PR TITLE
Address security vulnerabilities

### DIFF
--- a/webapp/src/pages/_app.tsx
+++ b/webapp/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { Provider as AuthProvider } from "next-auth/client";
+import { Session } from "next-auth";
 import { AppProps } from "next/app";
 import Head from "next/head";
 import React, { FunctionComponent, useEffect } from "react";
@@ -7,7 +8,7 @@ import "../styles/globals.scss";
 const BeaconRegistrationApp: FunctionComponent<AppProps> = ({
   Component,
   pageProps,
-}: AppProps): JSX.Element => {
+}: AppProps<{ session: Session }>): JSX.Element => {
   useEffect(() => {
     document.body.className = document.body.className
       ? document.body.className + " js-enabled"


### PR DESCRIPTION
In the release of next.js v12.3.0 the interface AppProps takes a generic instead of any

https://github.com/vercel/next.js/pull/38867
