### PR TITLE
MCA-45 Run tests on all pushes to development branches

### DIFF
--- a/.github/workflows/on-pre-release.yml
+++ b/.github/workflows/on-pre-release.yml
@@ -43,8 +43,6 @@ jobs:
   test_service:
     name: Test Service
     uses: ./.github/workflows/test-service.yml
-    with:
-      environment: staging
     secrets:
       microsoft_graph_client_id: ${{ secrets.MICROSOFT_GRAPH_CLIENT_ID }}
       microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -44,8 +44,6 @@ jobs:
   test_service:
     name: Test Service
     uses: ./.github/workflows/test-service.yml
-    with:
-      environment: development
     secrets:
       microsoft_graph_client_id: ${{ secrets.MICROSOFT_GRAPH_CLIENT_ID }}
       microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -63,8 +63,6 @@ jobs:
   test_service:
     name: Test Service
     uses: ./.github/workflows/test-service.yml
-    with:
-      environment: staging
     secrets:
       microsoft_graph_client_id: ${{ secrets.MICROSOFT_GRAPH_CLIENT_ID }}
       microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,13 +1,8 @@
-name: Tests
+name: Run tests
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   push:
-    branches:
-      - dependabot/**
+    branches-ignore:
+      - main
 jobs:
   docker:
     env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -59,3 +59,16 @@ jobs:
   test_backoffice:
     name: Test Backoffice
     uses: ./.github/workflows/test-backoffice.yml
+
+  test_service:
+    name: Test Service
+    uses: ./.github/workflows/test-service.yml
+    with:
+      environment: staging
+    secrets:
+      microsoft_graph_client_id: ${{ secrets.MICROSOFT_GRAPH_CLIENT_ID }}
+      microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}
+      microsoft_graph_b2c_tenant_id: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_ID }}
+      microsoft_graph_b2c_tenant_name: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_NAME }}
+
+  # Todo: We should probably run the end-to-end tests before merging

--- a/.github/workflows/test-service.yml
+++ b/.github/workflows/test-service.yml
@@ -2,13 +2,6 @@ name: Test Service
 
 on:
   workflow_call:
-    inputs:
-      environment:
-        description:
-          The environment to which the application should be deployed.  Must be one of development/staging/production
-          and must match the terraform_workspace input.
-        type: string
-        required: true
     secrets:
       microsoft_graph_client_id:
         description: The Azure AD B2C client id required for the beacons service API to call Microsoft Graph


### PR DESCRIPTION
## Context

As a software engineer working on Beacons
I want the tests to be run on all pushes to any branch
So that I can be confident in my changes before I merge them

## Changes in this pull request

* beacons/.github/workflows/dependabot-runs-tests.yml / Dependabot Tests 
  * Has been renamed to beacons/.github/workflows/run-tests.yml / Run tests
  * Is triggered on any push to any branch except main
  * Tests all four images:
    * webapp
    * service
    * backoffice

## Guidance to review

[Look at GitHub Actions for this branch](https://github.com/WillGibson/beacons/actions?query=branch%3AMCA-45-run-tests-on-all-pushes)

## Link to Trello card

N/A

## Things to check

N/A
