### PR TITLE
Require tests to pass before publishing images after merging to main

### DIFF
--- a/.github/workflows/on-pre-release.yml
+++ b/.github/workflows/on-pre-release.yml
@@ -55,6 +55,8 @@ jobs:
 
   publish_webapp_image:
     name: Webapp
+    needs:
+      - test_webapp
     uses: ./.github/workflows/publish-webapp-image.yml
     with:
       tag: ${{ github.event.release.tag_name }}
@@ -62,10 +64,11 @@ jobs:
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    needs: [test_webapp]
 
   publish_service_image:
     name: Service
+    needs:
+      - test_service
     uses: ./.github/workflows/publish-service-image.yml
     with:
       tag: ${{ github.event.release.tag_name }}
@@ -73,10 +76,11 @@ jobs:
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    needs: [test_service]
 
   publish_backoffice_image:
     name: Publish Backoffice
+    needs:
+      - test_backoffice
     uses: ./.github/workflows/publish-backoffice-image.yml
     with:
       tag: ${{ github.event.release.tag_name }}
@@ -86,7 +90,6 @@ jobs:
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       feedback_email_addresses: ${{ secrets.BACKOFFICE_FEEDBACK_EMAIL_ADDRESSES }}
       mui_pro_license_key: ${{ secrets.MUI_PRO_LICENSE_KEY }}
-    needs: [test_backoffice]
 
   publish_opensearch_proxy_image:
     name: OpenSearch proxy
@@ -101,12 +104,10 @@ jobs:
   end_to_end_tests:
     name: End-to-end tests
     needs:
-      [
-        publish_webapp_image,
-        publish_service_image,
-        publish_backoffice_image,
-        publish_opensearch_proxy_image,
-      ]
+      - publish_webapp_image
+      - publish_service_image
+      - publish_backoffice_image
+      - publish_opensearch_proxy_image
     uses: ./.github/workflows/end-to-end-tests.yml
     with:
       image-tag: ${{ github.sha }}
@@ -148,7 +149,10 @@ jobs:
 
   deploy_staging:
     name: Staging
-    needs: [end_to_end_tests, terraform_lint, prettier_check]
+    needs:
+      - end_to_end_tests
+      - terraform_lint
+      - prettier_check
     uses: ./.github/workflows/deploy.yml
     with:
       environment: staging

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -56,6 +56,8 @@ jobs:
 
   publish_webapp_image:
     name: Publish Webapp
+    needs:
+      - test_webapp
     uses: ./.github/workflows/publish-webapp-image.yml
     with:
       tag: ${{ github.sha }}
@@ -66,6 +68,8 @@ jobs:
 
   publish_service_image:
     name: Publish Service
+    needs:
+      - test_service
     uses: ./.github/workflows/publish-service-image.yml
     with:
       tag: ${{ github.sha }}
@@ -76,6 +80,8 @@ jobs:
 
   publish_backoffice_image:
     name: Publish Backoffice
+    needs:
+      - test_backoffice
     uses: ./.github/workflows/publish-backoffice-image.yml
     with:
       tag: ${{ github.sha }}
@@ -99,17 +105,15 @@ jobs:
   end_to_end_tests:
     name: End-to-end tests
     needs:
-      [
-        terraform_lint,
-        prettier_check,
-        test_webapp,
-        test_service,
-        test_backoffice,
-        publish_webapp_image,
-        publish_service_image,
-        publish_backoffice_image,
-        publish_opensearch_proxy_image,
-      ]
+      - terraform_lint
+      - prettier_check
+      - test_webapp
+      - test_service
+      - test_backoffice
+      - publish_webapp_image
+      - publish_service_image
+      - publish_backoffice_image
+      - publish_opensearch_proxy_image
     uses: ./.github/workflows/end-to-end-tests.yml
     with:
       image-tag: ${{ github.sha }}
@@ -132,12 +136,10 @@ jobs:
   deploy_dev:
     name: Development
     needs:
-      [
-        publish_backoffice_image,
-        publish_webapp_image,
-        publish_service_image,
-        publish_opensearch_proxy_image,
-      ]
+      - publish_backoffice_image
+      - publish_webapp_image
+      - publish_service_image
+      - publish_opensearch_proxy_image
     uses: ./.github/workflows/deploy.yml
     with:
       environment: development


### PR DESCRIPTION
## Context

We should not publish images if the tests are failing.

## Changes in this pull request

Made the `on-push.yml` workflow require the tests to pass before publishing.

Standardised the syntax and location of the `needs` arrays.

## Guidance to review

N/A

## Link to Trello card

N/A

## Things to check

N/A
