### PR TITLE
Enable run tests action for external developer pull requests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,6 +3,12 @@ on:
   push:
     branches-ignore:
       - main
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
 jobs:
   docker:
     env:


### PR DESCRIPTION
## Context

So that the test run before we merge contributions from outside the team.