### PR TITLE
Update run-tests.yml to use ci-test environment name to get secrets

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,7 +70,7 @@ jobs:
     name: Test Service
     uses: ./.github/workflows/test-service.yml
     with:
-      environment: development
+      environment: ci-test
     secrets:
       microsoft_graph_client_id: ${{ secrets.MICROSOFT_GRAPH_CLIENT_ID }}
       microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}


### PR DESCRIPTION
## Context

This change is so that we can run the service integration tests before merging to main.
