### PR TITLE
Require end-to-end tests to pass before deploying dev and staging

### DIFF
--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -142,6 +142,7 @@ jobs:
       - publish_webapp_image
       - publish_service_image
       - publish_opensearch_proxy_image
+      - end_to_end_tests
     uses: ./.github/workflows/_reusable-deploy.yml
     with:
       environment: development

--- a/.github/workflows/on-release-drafted.yml
+++ b/.github/workflows/on-release-drafted.yml
@@ -155,6 +155,7 @@ jobs:
       - end_to_end_tests
       - terraform_lint
       - prettier_check
+      - end_to_end_tests
     uses: ./.github/workflows/_reusable-deploy.yml
     with:
       environment: staging


### PR DESCRIPTION
## Context

Because we don't want to deploy something if the tests are failing.
