### PR TITLE
Don't publish any images unless all the pre-publishing tests have passed

### DIFF
--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -63,6 +63,8 @@ jobs:
   publish_webapp_image:
     name: Publish Webapp
     needs:
+      - test_backoffice
+      - test_service
       - test_webapp
     uses: ./.github/workflows/_reusable-publish-webapp-image.yml
     with:
@@ -75,7 +77,9 @@ jobs:
   publish_service_image:
     name: Publish Service
     needs:
+      - test_backoffice
       - test_service
+      - test_webapp
     uses: ./.github/workflows/_reusable-publish-service-image.yml
     with:
       tag: ${{ github.sha }}
@@ -88,6 +92,8 @@ jobs:
     name: Publish Backoffice
     needs:
       - test_backoffice
+      - test_service
+      - test_webapp
     uses: ./.github/workflows/_reusable-publish-backoffice-image.yml
     with:
       tag: ${{ github.sha }}
@@ -100,6 +106,10 @@ jobs:
 
   publish_opensearch_proxy_image:
     name: OpenSearch proxy
+    needs:
+      - test_backoffice
+      - test_service
+      - test_webapp
     uses: ./.github/workflows/_reusable-publish-opensearch-proxy-image.yml
     with:
       tag: ${{ github.sha }}

--- a/.github/workflows/on-release-drafted.yml
+++ b/.github/workflows/on-release-drafted.yml
@@ -62,6 +62,8 @@ jobs:
   publish_webapp_image:
     name: Webapp
     needs:
+      - test_backoffice
+      - test_service
       - test_webapp
     uses: ./.github/workflows/_reusable-publish-webapp-image.yml
     with:
@@ -74,7 +76,9 @@ jobs:
   publish_service_image:
     name: Service
     needs:
+      - test_backoffice
       - test_service
+      - test_webapp
     uses: ./.github/workflows/_reusable-publish-service-image.yml
     with:
       tag: ${{ github.event.release.tag_name }}
@@ -87,6 +91,8 @@ jobs:
     name: Publish Backoffice
     needs:
       - test_backoffice
+      - test_service
+      - test_webapp
     uses: ./.github/workflows/_reusable-publish-backoffice-image.yml
     with:
       tag: ${{ github.event.release.tag_name }}
@@ -99,6 +105,10 @@ jobs:
 
   publish_opensearch_proxy_image:
     name: OpenSearch proxy
+    needs:
+      - test_backoffice
+      - test_service
+      - test_webapp
     uses: ./.github/workflows/_reusable-publish-opensearch-proxy-image.yml
     with:
       tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Context

There is no point publishing any of the images unless all the unit tests etc. have passed becuase we are not going to use them.

This change should save a few pounds sterling and some carbons.