### PR TITLE
Remove pointless manual testing steps and correct name of pre-release action

### DIFF
--- a/.github/workflows/on-pre-release.yml
+++ b/.github/workflows/on-pre-release.yml
@@ -199,11 +199,3 @@ jobs:
       microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}
       microsoft_graph_b2c_tenant_id: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_ID }}
       microsoft_graph_b2c_tenant_name: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_NAME }}
-
-  manual_testing:
-    name: Manual testing
-    runs-on: ubuntu-latest
-    steps:
-      - name: Link to manual testing document
-        run: |
-          echo "::notice file=tests/pre-release-testing-scenarios.md,title={Remember to run through the pre-release testing scenarios before pushing to production}::This should be automated soon."

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -41,11 +41,3 @@ jobs:
       microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}
       microsoft_graph_b2c_tenant_id: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_ID }}
       microsoft_graph_b2c_tenant_name: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_NAME }}
-
-  manual_testing:
-    name: Manual testing
-    runs-on: ubuntu-latest
-    steps:
-      - name: Link to manual testing document
-        run: |
-          echo "::notice file=tests/post-release-testing-scenarios.md,title={Remember to run through the post-release testing scenarios immediately after pushing to production}::This should be automated soon."


### PR DESCRIPTION
## Context

The manual testing steps add no value.

Now I understand how we use pre-release, I have renamed that workflow file appropriately.