### PR TITLE
ci: Remove redundant CodeQL job

### DIFF
--- a/.github/workflows/on-pre-release.yml
+++ b/.github/workflows/on-pre-release.yml
@@ -143,26 +143,6 @@ jobs:
       microsoft_graph_b2c_tenant_id: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_ID }}
       microsoft_graph_b2c_tenant_name: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_NAME }}
 
-  codeql:
-    name: CodeQL check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          config-file: .github/codeql/codeql-config.yml
-          languages: java, typescript
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "adopt"
-          java-version: 11
-      - name: Compile code
-        working-directory: service
-        run: ./gradlew clean assemble
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-
   deploy_staging:
     name: Staging
     needs:


### PR DESCRIPTION
## Context

My attention was captured by it failing when uploading results...

```
  Uploading results
  Warning: Resource not accessible by integration - https://docs.github.com/rest
  Error: Resource not accessible by integration - https://docs.github.com/rest
  Warning: Resource not accessible by integration - https://docs.github.com/rest
```

It is not needed, static code analysis is happening without it.

## Changes in this pull request

Remove the redundant job.
