### PR TITLE
feat(api)!: refactor endpoint using JPA Specification and CriteriaBuilder

### DIFF
--- a/backoffice/src/components/BeaconsTable.tsx
+++ b/backoffice/src/components/BeaconsTable.tsx
@@ -222,21 +222,22 @@ export const BeaconsTable: FunctionComponent<IBeaconsTableProps> = React.memo(
               const response = await beaconsGateway.getAllBeacons(
                 ...buildTableQuery(query),
               );
-              const beacons = response._embedded.beaconSearch.map(
-                (item: IBeaconSearchResultData): BeaconRowData => ({
-                  createdDate: item.createdDate,
-                  lastModifiedDate: item.lastModifiedDate,
-                  beaconStatus: item.beaconStatus,
-                  hexId: item.hexId,
-                  ownerName: item.ownerName ?? "N/A",
-                  useActivities: item.useActivities ?? "N/A",
-                  id: item.id,
-                  beaconType: item.beaconType,
-                  cospasSarsatNumber: item.cospasSarsatNumber ?? "N/A",
-                  manufacturerSerialNumber:
-                    item.manufacturerSerialNumber ?? "N/A",
-                }),
-              );
+              const beacons =
+                response._embedded?.beaconSearchEntities?.map(
+                  (item: IBeaconSearchResultData): BeaconRowData => ({
+                    createdDate: item.createdDate,
+                    lastModifiedDate: item.lastModifiedDate,
+                    beaconStatus: item.beaconStatus,
+                    hexId: item.hexId,
+                    ownerName: item.ownerName ?? "N/A",
+                    useActivities: item.useActivities ?? "N/A",
+                    id: item.id,
+                    beaconType: item.beaconType,
+                    cospasSarsatNumber: item.cospasSarsatNumber ?? "N/A",
+                    manufacturerSerialNumber:
+                      item.manufacturerSerialNumber ?? "N/A",
+                  }),
+                ) ?? [];
               resolve({
                 data: beacons,
                 page: response.page.number,

--- a/backoffice/src/entities/IBeaconSearchResult.ts
+++ b/backoffice/src/entities/IBeaconSearchResult.ts
@@ -6,7 +6,7 @@ export interface IBeaconSearchResult {
     number: number;
   };
 
-  _embedded: { beaconSearch: IBeaconSearchResultData[] };
+  _embedded: { beaconSearchEntities: IBeaconSearchResultData[] };
 }
 
 export interface IBeaconSearchResultData {

--- a/backoffice/src/fixtures/beaconSearchResult.fixture.ts
+++ b/backoffice/src/fixtures/beaconSearchResult.fixture.ts
@@ -9,7 +9,7 @@ export const beaconSearchResultFixture = deepFreeze<IBeaconSearchResult>({
     number: 0,
   },
   _embedded: {
-    beaconSearch: [
+    beaconSearchEntities: [
       {
         id: "97b306aa-cbd0-4f09-aa24-2d876b983efb",
         hexId: "Hex me",

--- a/backoffice/src/gateways/beacons/BeaconsGateway.test.ts
+++ b/backoffice/src/gateways/beacons/BeaconsGateway.test.ts
@@ -55,7 +55,7 @@ describe("BeaconsGateway", () => {
       await gateway.getAllBeacons("", {}, 0, 20, null);
 
       expect(axios.get).toHaveBeenCalledWith(
-        `${applicationConfig.apiUrl}/beacon-search/search/find-allv2?term=&status=&uses=\
+        `${applicationConfig.apiUrl}/search/beacons/find-all?term=&status=&uses=\
 &hexId=&ownerName=&cospasSarsatNumber=&manufacturerSerialNumber=&page=0&size=20&sort=`,
         config,
       );

--- a/backoffice/src/gateways/beacons/BeaconsGateway.ts
+++ b/backoffice/src/gateways/beacons/BeaconsGateway.ts
@@ -140,7 +140,7 @@ export class BeaconsGateway implements IBeaconsGateway {
 
     const sortString = sort ? `${sort[0]},${sort[1]}` : "";
 
-    return `/beacon-search/search/find-allv2?term=${term}&status=${status}&uses=${uses}&hexId=${hexId}\
+    return `/search/beacons/find-all?term=${term}&status=${status}&uses=${uses}&hexId=${hexId}\
 &ownerName=${ownerName}&cospasSarsatNumber=${cospasSarsatNumber}\
 &manufacturerSerialNumber=${manufacturerSerialNumber}&page=${page}&size=${size}&sort=${sortString}`;
   }

--- a/service/src/main/java/uk/gov/mca/beacons/api/search/beacons/repositories/BeaconSearchRepository.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/search/beacons/repositories/BeaconSearchRepository.java
@@ -1,0 +1,13 @@
+package uk.gov.mca.beacons.api.search.beacons.repositories;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+import uk.gov.mca.beacons.api.search.domain.BeaconSearchEntity;
+
+@Repository
+public interface BeaconSearchRepository
+  extends
+    JpaRepository<BeaconSearchEntity, UUID>,
+    JpaSpecificationExecutor<BeaconSearchEntity> {}

--- a/service/src/main/java/uk/gov/mca/beacons/api/search/beacons/rest/BeaconSearchController.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/search/beacons/rest/BeaconSearchController.java
@@ -1,0 +1,95 @@
+package uk.gov.mca.beacons.api.search.beacons.rest;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.mca.beacons.api.search.BeaconSearchService;
+import uk.gov.mca.beacons.api.search.domain.BeaconSearchEntity;
+
+@Slf4j
+@RestController
+@RequestMapping("/spring-api/search/beacons")
+@Tag(name = "FindAllBeacons")
+public class BeaconSearchController {
+
+  private final BeaconSearchService beaconSearchService;
+  private final PagedResourcesAssembler<BeaconSearchEntity> pagedAssembler;
+
+  @Autowired
+  public BeaconSearchController(
+    BeaconSearchService beaconSearchService,
+    PagedResourcesAssembler<BeaconSearchEntity> pagedAssembler
+  ) {
+    this.beaconSearchService = beaconSearchService;
+    this.pagedAssembler = pagedAssembler;
+  }
+
+  @Cacheable(value = "find-all-beacons")
+  @GetMapping("/find-all")
+  @Operation(summary = "Find all beacons matching specific fields (paginated)")
+  public ResponseEntity<
+    PagedModel<EntityModel<BeaconSearchEntity>>
+  > findAllBeacons(
+    @RequestParam(required = false, defaultValue = "") String status,
+    @RequestParam(required = false, defaultValue = "") String uses,
+    @RequestParam(required = false, defaultValue = "") String hexId,
+    @RequestParam(required = false, defaultValue = "") String ownerName,
+    @RequestParam(
+      required = false,
+      defaultValue = ""
+    ) String cospasSarsatNumber,
+    @RequestParam(
+      required = false,
+      defaultValue = ""
+    ) String manufacturerSerialNumber,
+    Pageable pageable
+  ) {
+    Page<BeaconSearchEntity> results = beaconSearchService.findAllBeacons(
+      status,
+      uses,
+      hexId,
+      ownerName,
+      cospasSarsatNumber,
+      manufacturerSerialNumber,
+      pageable
+    );
+
+    var pagedModel = pagedAssembler.toModel(
+      results,
+      beacon ->
+        EntityModel.of(
+          beacon,
+          linkTo(BeaconSearchController.class)
+            .slash(beacon.getId())
+            .withSelfRel(),
+          linkTo(BeaconSearchController.class)
+            .slash(beacon.getId())
+            .withRel("beaconSearchEntity")
+        ),
+      linkTo(
+        methodOn(BeaconSearchController.class).findAllBeacons(
+          status,
+          uses,
+          hexId,
+          ownerName,
+          cospasSarsatNumber,
+          manufacturerSerialNumber,
+          pageable
+        )
+      ).withSelfRel()
+    );
+
+    return ResponseEntity.ok(pagedModel);
+  }
+}

--- a/service/src/main/java/uk/gov/mca/beacons/api/search/beacons/rest/BeaconSearchSpecification.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/search/beacons/rest/BeaconSearchSpecification.java
@@ -1,0 +1,87 @@
+package uk.gov.mca.beacons.api.search.beacons.rest;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+import uk.gov.mca.beacons.api.search.domain.BeaconSearchEntity;
+
+public class BeaconSearchSpecification {
+
+  public static @Nullable Specification<BeaconSearchEntity> hasStatus(
+    String status
+  ) {
+    if (StringUtils.hasText(status)) {
+      return (root, query, cb) ->
+        likeLower(cb, root.get("beaconStatus"), status);
+    }
+    return null;
+  }
+
+  public static @Nullable Specification<BeaconSearchEntity> hasUses(
+    String uses
+  ) {
+    if (StringUtils.hasText(uses)) {
+      return (root, query, cb) ->
+        likeLower(cb, root.get("useActivities"), uses);
+    }
+    return null;
+  }
+
+  public static @Nullable Specification<BeaconSearchEntity> hasHexId(
+    String hexId
+  ) {
+    if (StringUtils.hasText(hexId)) {
+      return (root, query, cb) -> likeLower(cb, root.get("hexId"), hexId);
+    }
+    return null;
+  }
+
+  public static @Nullable Specification<BeaconSearchEntity> hasOwnerName(
+    String ownerName
+  ) {
+    if (StringUtils.hasText(ownerName)) {
+      return (root, query, cb) ->
+        likeLower(cb, root.get("ownerName"), ownerName);
+    }
+    return null;
+  }
+
+  public static @Nullable Specification<
+    BeaconSearchEntity
+  > hasCospasSarsatNumber(String cospasSarsatNumber) {
+    if (StringUtils.hasText(cospasSarsatNumber)) {
+      return (root, query, cb) ->
+        likeLower(cb, root.get("cospasSarsatNumber"), cospasSarsatNumber);
+    }
+    return null;
+  }
+
+  public static @Nullable Specification<
+    BeaconSearchEntity
+  > hasManufacturerSerialNumber(String manufacturerSerialNumber) {
+    if (StringUtils.hasText(manufacturerSerialNumber)) {
+      return (root, query, cb) ->
+        likeLower(
+          cb,
+          root.get("manufacturerSerialNumber"),
+          manufacturerSerialNumber
+        );
+    }
+    return null;
+  }
+
+  private static Predicate likeLower(
+    @NotNull CriteriaBuilder cb,
+    Expression<String> expression,
+    @NotNull String pattern
+  ) {
+    return cb.like(
+      cb.lower(cb.coalesce(expression, "")),
+      "%" + pattern.toLowerCase() + "%"
+    );
+  }
+}

--- a/service/src/main/java/uk/gov/mca/beacons/api/search/jobs/steps/BeaconSearchDocumentWriter.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/search/jobs/steps/BeaconSearchDocumentWriter.java
@@ -6,23 +6,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import uk.gov.mca.beacons.api.search.documents.BeaconSearchDocument;
-import uk.gov.mca.beacons.api.search.repositories.BeaconSearchRepository;
+import uk.gov.mca.beacons.api.search.repositories.BeaconElasticSearchRepository;
 
 @Component
 public class BeaconSearchDocumentWriter
   implements ItemWriter<BeaconSearchDocument> {
 
-  private final BeaconSearchRepository beaconSearchRepository;
+  private final BeaconElasticSearchRepository beaconElasticSearchRepository;
 
   @Autowired
   public BeaconSearchDocumentWriter(
-    BeaconSearchRepository beaconSearchRepository
+    BeaconElasticSearchRepository beaconElasticSearchRepository
   ) {
-    this.beaconSearchRepository = beaconSearchRepository;
+    this.beaconElasticSearchRepository = beaconElasticSearchRepository;
   }
 
   @Override
   public void write(@NonNull List<? extends BeaconSearchDocument> documents) {
-    beaconSearchRepository.saveAll(documents);
+    beaconElasticSearchRepository.saveAll(documents);
   }
 }

--- a/service/src/main/java/uk/gov/mca/beacons/api/search/repositories/BeaconElasticSearchRepository.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/search/repositories/BeaconElasticSearchRepository.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import uk.gov.mca.beacons.api.search.documents.BeaconSearchDocument;
 
-public interface BeaconSearchRepository
+public interface BeaconElasticSearchRepository
   extends ElasticsearchRepository<BeaconSearchDocument, UUID> {
   BeaconSearchDocument findBeaconSearchDocumentByHexId(String hexId);
 }

--- a/service/src/test/java/uk/gov/mca/beacons/api/search/BeaconSearchServiceUnitTest.java
+++ b/service/src/test/java/uk/gov/mca/beacons/api/search/BeaconSearchServiceUnitTest.java
@@ -1,15 +1,11 @@
 package uk.gov.mca.beacons.api.search;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Objects;
@@ -21,6 +17,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import uk.gov.mca.beacons.api.beacon.domain.Beacon;
 import uk.gov.mca.beacons.api.beacon.domain.BeaconId;
 import uk.gov.mca.beacons.api.beacon.domain.BeaconRepository;
@@ -30,14 +31,19 @@ import uk.gov.mca.beacons.api.beaconowner.domain.BeaconOwnerRepository;
 import uk.gov.mca.beacons.api.beaconuse.domain.BeaconUse;
 import uk.gov.mca.beacons.api.beaconuse.domain.BeaconUseRepository;
 import uk.gov.mca.beacons.api.legacybeacon.domain.*;
+import uk.gov.mca.beacons.api.search.beacons.repositories.BeaconSearchRepository;
 import uk.gov.mca.beacons.api.search.documents.BeaconSearchDocument;
-import uk.gov.mca.beacons.api.search.repositories.BeaconSearchRepository;
+import uk.gov.mca.beacons.api.search.domain.BeaconSearchEntity;
+import uk.gov.mca.beacons.api.search.repositories.BeaconElasticSearchRepository;
 
 @ExtendWith(MockitoExtension.class)
 public class BeaconSearchServiceUnitTest {
 
   @InjectMocks
   BeaconSearchService beaconSearchService;
+
+  @Mock
+  BeaconElasticSearchRepository beaconElasticSearchRepository;
 
   @Mock
   BeaconSearchRepository beaconSearchRepository;
@@ -75,7 +81,9 @@ public class BeaconSearchServiceUnitTest {
     ).willReturn(List.of(mockBeaconUse));
     beaconSearchService.index(mockBeacon.getId());
 
-    verify(beaconSearchRepository, times(1)).save(argumentCaptor.capture());
+    verify(beaconElasticSearchRepository, times(1)).save(
+      argumentCaptor.capture()
+    );
 
     BeaconSearchDocument beaconSearchDocument = argumentCaptor.getValue();
     assertThat(
@@ -113,7 +121,9 @@ public class BeaconSearchServiceUnitTest {
     ).willReturn(List.of());
     beaconSearchService.index(mockBeacon.getId());
 
-    verify(beaconSearchRepository, times(1)).save(argumentCaptor.capture());
+    verify(beaconElasticSearchRepository, times(1)).save(
+      argumentCaptor.capture()
+    );
 
     BeaconSearchDocument beaconSearchDocument = argumentCaptor.getValue();
     assertThat(
@@ -147,7 +157,9 @@ public class BeaconSearchServiceUnitTest {
 
     beaconSearchService.index(mockLegacyBeacon.getId());
 
-    verify(beaconSearchRepository, times(1)).save(argumentCaptor.capture());
+    verify(beaconElasticSearchRepository, times(1)).save(
+      argumentCaptor.capture()
+    );
 
     BeaconSearchDocument beaconSearchDocument = argumentCaptor.getValue();
     assertThat(
@@ -165,6 +177,80 @@ public class BeaconSearchServiceUnitTest {
     assertThrows(IllegalArgumentException.class, () ->
       beaconSearchService.index(new LegacyBeaconId(UUID.randomUUID()))
     );
+  }
+
+  @Test
+  public void givenFindAllBeacons_WithValidFilters_ThenShouldCallRepositoryWithSpecificationAndPageable() {
+    String status = "status";
+    String uses = "uses";
+    String hexID = "hexID";
+    String ownerName = "ownerName";
+    String cospasSarsatNumber = "cospasSarsatNumber";
+    String manufacturerSerialNumber = "manufacturerSerialNumber";
+
+    Pageable pageable = PageRequest.of(0, 20);
+
+    List<BeaconSearchEntity> beacons = List.of(new BeaconSearchEntity());
+    Page<BeaconSearchEntity> expectedPage = new PageImpl<>(
+      beacons,
+      pageable,
+      1
+    );
+
+    when(
+      beaconSearchRepository.findAll(any(Specification.class), eq(pageable))
+    ).thenReturn(expectedPage);
+
+    Page<BeaconSearchEntity> result = beaconSearchService.findAllBeacons(
+      status,
+      uses,
+      hexID,
+      ownerName,
+      cospasSarsatNumber,
+      manufacturerSerialNumber,
+      pageable
+    );
+
+    assertThat(result, equalTo(expectedPage));
+    assertThat(result.getContent(), hasSize(1));
+    verify(beaconSearchRepository, times(1)).findAll(
+      any(Specification.class),
+      eq(pageable)
+    );
+  }
+
+  @Test
+  public void givenFindAllBeacons_WithInvalidFilters_ThenShouldReturnEmptyPageable() {
+    String status = "status";
+    String uses = "uses";
+    String hexID = "hexID";
+    String ownerName = "ownerName";
+    String cospasSarsatNumber = "cospasSarsatNumber";
+    String manufacturerSerialNumber = "manufacturerSerialNumber";
+
+    Pageable pageable = PageRequest.of(0, 20);
+
+    Page<BeaconSearchEntity> expectedPage = Page.empty(pageable);
+
+    when(
+      beaconSearchRepository.findAll(any(Specification.class), eq(pageable))
+    ).thenReturn(expectedPage);
+
+    Page<BeaconSearchEntity> result = beaconSearchService.findAllBeacons(
+      status,
+      uses,
+      hexID,
+      ownerName,
+      cospasSarsatNumber,
+      manufacturerSerialNumber,
+      pageable
+    );
+
+    assertThat(result, equalTo(expectedPage));
+    assertThat(result.getContent(), empty());
+    assertThat(result.getSize(), equalTo(20));
+    assertThat(result.getTotalPages(), equalTo(0));
+    assertThat(result.getNumber(), equalTo(0));
   }
 
   private Beacon createMockBeacon(BeaconStatus status) {

--- a/service/src/test/java/uk/gov/mca/beacons/api/search/documents/BeaconSearchDocumentIntegrationTest.java
+++ b/service/src/test/java/uk/gov/mca/beacons/api/search/documents/BeaconSearchDocumentIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import java.time.OffsetDateTime;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -12,15 +11,14 @@ import org.apache.commons.collections.IteratorUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.mca.beacons.api.BaseIntegrationTest;
-import uk.gov.mca.beacons.api.beacon.domain.Beacon;
 import uk.gov.mca.beacons.api.search.documents.nested.NestedBeaconOwner;
 import uk.gov.mca.beacons.api.search.documents.nested.NestedBeaconUse;
-import uk.gov.mca.beacons.api.search.repositories.BeaconSearchRepository;
+import uk.gov.mca.beacons.api.search.repositories.BeaconElasticSearchRepository;
 
 public class BeaconSearchDocumentIntegrationTest extends BaseIntegrationTest {
 
   @Autowired
-  BeaconSearchRepository beaconSearchRepository;
+  BeaconElasticSearchRepository beaconElasticSearchRepository;
 
   @Test
   void shouldSaveAndRetrieveTheBeaconSearchDocument() {
@@ -52,12 +50,12 @@ public class BeaconSearchDocumentIntegrationTest extends BaseIntegrationTest {
     beaconSearchDocument.setBeaconOwner(beaconOwner);
 
     // act
-    BeaconSearchDocument savedDocument = beaconSearchRepository.save(
+    BeaconSearchDocument savedDocument = beaconElasticSearchRepository.save(
       beaconSearchDocument
     );
 
     BeaconSearchDocument retrievedDocument =
-      beaconSearchRepository.findBeaconSearchDocumentByHexId(hexId);
+      beaconElasticSearchRepository.findBeaconSearchDocumentByHexId(hexId);
 
     // assert
     assertThat(retrievedDocument.getHexId(), equalTo(hexId));
@@ -93,11 +91,11 @@ public class BeaconSearchDocumentIntegrationTest extends BaseIntegrationTest {
     beaconSearchDocument.setBeaconOwner(beaconOwner);
 
     // act
-    BeaconSearchDocument savedDocument = beaconSearchRepository.save(
+    BeaconSearchDocument savedDocument = beaconElasticSearchRepository.save(
       beaconSearchDocument
     );
 
-    Iterator records = beaconSearchRepository.findAll().iterator();
+    Iterator records = beaconElasticSearchRepository.findAll().iterator();
     List<BeaconSearchDocument> retrievedDocuments = IteratorUtils.toList(
       records
     );

--- a/service/src/test/java/uk/gov/mca/beacons/api/search/jobs/configuration/ReindexSearchJobConfigurationIntegrationTest.java
+++ b/service/src/test/java/uk/gov/mca/beacons/api/search/jobs/configuration/ReindexSearchJobConfigurationIntegrationTest.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import uk.gov.mca.beacons.api.WebIntegrationTest;
 import uk.gov.mca.beacons.api.search.documents.BeaconSearchDocument;
-import uk.gov.mca.beacons.api.search.repositories.BeaconSearchRepository;
+import uk.gov.mca.beacons.api.search.repositories.BeaconElasticSearchRepository;
 
 public class ReindexSearchJobConfigurationIntegrationTest
   extends WebIntegrationTest {
@@ -30,7 +30,7 @@ public class ReindexSearchJobConfigurationIntegrationTest
   private JobRepositoryTestUtils jobRepositoryTestUtils;
 
   @Autowired
-  BeaconSearchRepository beaconSearchRepository;
+  BeaconElasticSearchRepository beaconElasticSearchRepository;
 
   @Autowired
   @Qualifier("reindexSearchJob")
@@ -56,7 +56,7 @@ public class ReindexSearchJobConfigurationIntegrationTest
     );
     ExitStatus exitStatus = jobExecution.getExitStatus();
     List<BeaconSearchDocument> beaconSearchDocuments = new ArrayList<>();
-    beaconSearchRepository
+    beaconElasticSearchRepository
       .findAll()
       .iterator()
       .forEachRemaining(beaconSearchDocuments::add);

--- a/service/src/test/java/uk/gov/mca/beacons/api/search/rest/BeaconSearchRestRepositoryIntegrationTest.java
+++ b/service/src/test/java/uk/gov/mca/beacons/api/search/rest/BeaconSearchRestRepositoryIntegrationTest.java
@@ -226,6 +226,184 @@ class BeaconSearchRestRepositoryIntegrationTest extends WebIntegrationTest {
     }
   }
 
+  @Nested
+  class GetFindAllBeaconsResults {
+
+    private static final String FIND_ALL_BEACONS_URI =
+      "/spring-api/search/beacons/find-all";
+
+    @Test
+    void shouldFindTheLegacyBeaconByHexIdStatusAndUses() throws Exception {
+      final var randomHexId = UUID.randomUUID().toString();
+      createLegacyBeacon(randomHexId);
+
+      webTestClient
+        .get()
+        .uri(uriBuilder ->
+          uriBuilder
+            .path(FIND_ALL_BEACONS_URI)
+            .queryParam("status", "migrated")
+            .queryParam("uses", "maritime")
+            .queryParam("hexId", randomHexId)
+            .queryParam("ownerName", "")
+            .queryParam("cospasSarsatNumber", "")
+            .queryParam("manufacturerSerialNumber", "")
+            .build()
+        )
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("_embedded.beaconSearch[0].hexId")
+        .isEqualTo(randomHexId)
+        .jsonPath("page.totalElements")
+        .isEqualTo(1);
+    }
+
+    @Test
+    void shouldFindTheCreatedBeaconByHexIdStatusAndUses() throws Exception {
+      final String accountHolderId = seedAccountHolder();
+      final var randomHexId = UUID.randomUUID().toString();
+      createBeacon(randomHexId, accountHolderId);
+
+      webTestClient
+        .get()
+        .uri(uriBuilder ->
+          uriBuilder
+            .path(FIND_ALL_BEACONS_URI)
+            .queryParam("status", "new")
+            .queryParam("uses", "fishing vessel")
+            .queryParam("hexId", randomHexId)
+            .queryParam("ownerName", "")
+            .queryParam("cospasSarsatNumber", "")
+            .queryParam("manufacturerSerialNumber", "")
+            .build()
+        )
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("_embedded.beaconSearch[0].hexId")
+        .isEqualTo(randomHexId)
+        .jsonPath("page.totalElements")
+        .isEqualTo(1);
+    }
+
+    @Test
+    void shouldFindTheCreatedLegacyBeaconWithAllFiltersSet() throws Exception {
+      var legacyBeaconFixtureHexId = "9D0E1D1B8C00001";
+      var legacyBeaconFixtureOwnerName = "Mr Beacon";
+      var legacyBeaconFixtureCospasSarsatNumberValue = 476899;
+      var legacyBeaconFixtureManufacturerSerialNumber =
+        "manufacturer_serial_number_value";
+
+      var random = new Random();
+      var uniqueLegacyBeaconHexId = UUID.randomUUID().toString();
+      var uniqueLegacyBeaconOwnerName = UUID.randomUUID().toString();
+      var pseudoUniqueLegacyBeaconCospasSarsatNumber = random.nextInt(
+        Integer.MAX_VALUE
+      );
+      var uniqueLegacyBeaconManufacturerSerialNumber = UUID.randomUUID()
+        .toString();
+
+      createLegacyBeacon(request ->
+        request
+          .replace(legacyBeaconFixtureHexId, uniqueLegacyBeaconHexId)
+          .replace(legacyBeaconFixtureOwnerName, uniqueLegacyBeaconOwnerName)
+          .replace(
+            Integer.toString(legacyBeaconFixtureCospasSarsatNumberValue),
+            Integer.toString(pseudoUniqueLegacyBeaconCospasSarsatNumber)
+          )
+          .replace(
+            legacyBeaconFixtureManufacturerSerialNumber,
+            uniqueLegacyBeaconManufacturerSerialNumber
+          )
+      );
+
+      webTestClient
+        .get()
+        .uri(uriBuilder ->
+          uriBuilder
+            .path(FIND_ALL_BEACONS_URI)
+            .queryParam("status", "MIGRATED")
+            .queryParam("uses", "MARITIME")
+            .queryParam("hexId", uniqueLegacyBeaconHexId)
+            .queryParam("ownerName", uniqueLegacyBeaconOwnerName)
+            .queryParam(
+              "cospasSarsatNumber",
+              pseudoUniqueLegacyBeaconCospasSarsatNumber
+            )
+            .queryParam(
+              "manufacturerSerialNumber",
+              uniqueLegacyBeaconManufacturerSerialNumber
+            )
+            .build()
+        )
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("page.totalElements")
+        .isEqualTo(1)
+        .jsonPath("_embedded.beaconSearch[0].hexId")
+        .isEqualTo(uniqueLegacyBeaconHexId);
+    }
+
+    @Test
+    void shouldFindTheHATEOASLink() throws Exception {
+      final String accountHolderId = seedAccountHolder();
+      final var randomHexId = UUID.randomUUID().toString();
+      createBeacon(randomHexId, accountHolderId);
+
+      webTestClient
+        .get()
+        .uri(uriBuilder ->
+          uriBuilder
+            .path(FIND_ALL_BEACONS_URI)
+            .queryParam("status", "new")
+            .queryParam("uses", "fishing vessel")
+            .queryParam("hexId", randomHexId)
+            .queryParam("ownerName", "")
+            .queryParam("cospasSarsatNumber", "")
+            .queryParam("manufacturerSerialNumber", "")
+            .build()
+        )
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("_links.self.href")
+        .isNotEmpty();
+    }
+
+    @Test
+    void shouldFindTheHATEOASEntityLink() throws Exception {
+      final String accountHolderId = seedAccountHolder();
+      final var randomHexId = UUID.randomUUID().toString();
+      createBeacon(randomHexId, accountHolderId);
+
+      webTestClient
+        .get()
+        .uri(uriBuilder ->
+          uriBuilder
+            .path(FIND_ALL_BEACONS_URI)
+            .queryParam("status", "new")
+            .queryParam("uses", "fishing vessel")
+            .queryParam("hexId", randomHexId)
+            .queryParam("ownerName", "")
+            .queryParam("cospasSarsatNumber", "")
+            .queryParam("manufacturerSerialNumber", "")
+            .build()
+        )
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("_embedded.beaconSearch[0]._links.beaconSearchEntity.href")
+        .isNotEmpty();
+    }
+  }
+
   private String readFile(String filePath) throws Exception {
     return Files.readString(Paths.get(filePath));
   }


### PR DESCRIPTION
## Context

Given the issues we experiencing with backoffice slow query speeds and timeout issues. We want to refactor the search query in order to improve speeds.

## Changes in this pull request

- rename existing BeaconSearchRepository to BeaconElasticSearchRepository
- extend a new BeaconSearchRepository with JpaSpecificationExecutor to support dynamic queries using JPA Specifications
- created BeaconSearchSpecification class to build our dynamic queries for status, hexID, ownerName etc.
- create a service method to combine the filters based on search queries
- replicated the hypermedia-driven rel attribute in the @RestResource annotation using the link builder with Spring HATEOAS with integration tests.
- added some integration and unit tests


### Before
<img width="549" alt="image" src="https://github.com/user-attachments/assets/5b0949d0-7a05-4f7a-b1aa-52c09069628c" />

### After
<img width="380" alt="image" src="https://github.com/user-attachments/assets/085df12f-bf21-42dc-927c-a3fefcbe8770" />

## [Link to Zendesk](https://madetechsupport.zendesk.com/agent/tickets/188-)
