### PR TITLE
docs: Add clean to the service test commands

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -58,9 +58,9 @@ Both unit and integration tests go in [src/test/java/uk/gov/mca/beacons/api](src
 
 ### Running tests
 
-- `./gradlew test` runs unit tests
-- `./gradlew integrationTest` runs integration tests
-- `./gradlew check` runs both unit and integration tests
+- `./gradlew clean test` runs unit tests
+- `./gradlew clean integrationTest` runs integration tests
+- `./gradlew clean check` runs both unit and integration tests
 
 You can run the tests in Intellij for better click through, debugging etc. For the integration tests to work, make sure the run command in the run configuration starts with `:integretionTest`, not `:test`.
 


### PR DESCRIPTION
## Context

Because Gradle tries to be clever and not run the tests if it thinks nothing has changed, e.g. you flipped branch.