### PR TITLE
fix for backoffice path not being set to /backoffice

### DIFF
--- a/backoffice/src/components/layout/Footer.tsx
+++ b/backoffice/src/components/layout/Footer.tsx
@@ -27,7 +27,7 @@ export const Footer: FunctionComponent = (): JSX.Element | null => {
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
           <img
-            src="/mca-logo-dark.png"
+            src={import.meta.env.BASE_URL + "/mca-logo-dark.png"}
             alt="mca logo"
             className={classes.mcaLogo}
           />

--- a/backoffice/src/views/exports/certificates/BaseCertificate.tsx
+++ b/backoffice/src/views/exports/certificates/BaseCertificate.tsx
@@ -66,7 +66,7 @@ export const CertificateHeader: FunctionComponent<BeaconExportProps> = ({
       </div>
       <div className="logo">
         <img
-          src="/mca-logo.png"
+          src={import.meta.env.BASE_URL + "/mca-logo.png"}
           alt="Maritime &amp; Coastguard Agency"
           className="mcaLogo"
         />

--- a/backoffice/src/views/exports/letters/CoverLetter.tsx
+++ b/backoffice/src/views/exports/letters/CoverLetter.tsx
@@ -25,7 +25,7 @@ export const CoverLetter: FunctionComponent<LetterProps> = ({
         <div className="half">
           <p className="bold">OFFICIAL</p>
           <img
-            src="/mca-logo.png"
+            src={import.meta.env.BASE_URL + "/mca-logo.png"}
             alt="Maritime &amp; Coastguard Agency"
             className="mcaLogo"
           />

--- a/backoffice/vite.config.ts
+++ b/backoffice/vite.config.ts
@@ -5,12 +5,15 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: "/backoffice",
   plugins: [react(), svgr(), tsconfigPaths()],
   server: {
     open: true,
     port: 3001,
     proxy: {
-      "/backoffice": "http://localhost:3005",
+      "/backoffice/client-id": "http://localhost:3005",
+      "/backoffice/tenant-id": "http://localhost:3005",
+      "/backoffice/log": "http://localhost:3005",
     },
   },
   define: {


### PR DESCRIPTION
## Context

when upgrading from react-scripts to vite the baseurl setting was overlooked. it seems reacts-scripts infered this baseulr from `package.json` setting `"homepage": "/backoffice"`. this now needs setting in vite config explicitly and relative paths for assets updating also using the special env var https://vite.dev/guide/build.html#public-base-path

## Changes in this pull request

update to vite.config.js
updates to the paths for static assets
