### PR TITLE
fix: opensearch docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - postgres
     depends_on:
       opensearch:
-        condition: service_healthy
+        condition: service_started
       postgres:
         condition: service_started
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - /tmp/beacons:/var/export
     depends_on:
       opensearch:
-        condition: service_healthy
+        condition: service_started
       postgres:
         condition: service_started
 


### PR DESCRIPTION
## Context
 change to service start as no healthcheck is defined in opensearch container in the docker compose file
