### PR TITLE
Signposting end2end test failures

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -14,9 +14,9 @@ $ docker compose -f docker-compose.e2e.yml up
 $ npm run test:e2e
 ```
 
-### Failures
+### Occasional Failures
 
-- They require the `SESSION_TOKEN`, and may fail due to rotating session tokens. To resolve this, log into local/dev/staging with beacons_test\_b2c@mailsac.com (password in 1password). Locate the session token in dev tools: Application -> cookies -> \_\_Secure-next-auth.session-token -> value.
+- Automated end-to-end tests require the `SESSION_TOKEN`, and may fail unexpectedly, due to rotating session tokens. To resolve this, log into local/dev/staging with beacons_test\_b2c@mailsac.com (password in 1password). Locate the session token in dev tools: Application -> cookies -> \_\_Secure-next-auth.session-token -> value.
   Copy this value and update the corresponding secret in the GitHub repository.
 
 ## Smoke testing

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,11 @@ $ docker compose -f docker-compose.e2e.yml up
 $ npm run test:e2e
 ```
 
+### Failures
+
+- They require the `SESSION_TOKEN`, and may fail due to rotating session tokens. To resolve this, log into local/dev/staging with beacons_test\_b2c@mailsac.com (password in 1password). Locate the session token in dev tools: Application -> cookies -> \_\_Secure-next-auth.session-token -> value.
+  Copy this value and update the corresponding secret in the GitHub repository.
+
 ## Smoke testing
 
 The smoke tests are currently manual. We are looking to automate these.

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,8 +16,8 @@ $ npm run test:e2e
 
 ### Occasional Failures
 
-- Automated end-to-end tests require the `SESSION_TOKEN`, and may fail unexpectedly, due to rotating session tokens. To resolve this, log into local/dev/staging with beacons_test\_b2c@mailsac.com (password in 1password). Locate the session token in dev tools: Application -> cookies -> \_\_Secure-next-auth.session-token -> value.
-  Copy this value and update the corresponding secret in the GitHub repository.
+- Automated end-to-end tests require the `SESSION_TOKEN`, and may fail unexpectedly, due to rotating session tokens. To resolve this, log into local/dev/staging. Locate the session token in dev tools: Application -> cookies -> \_\_Secure-next-auth.session-token -> value.
+- Copy this value and update the corresponding secret in the GitHub repository.
 
 ## Smoke testing
 


### PR DESCRIPTION
## Context

Signposting this to help with test failures.

