### PR TITLE
fix: fuzzy search is not required for status param

### DIFF
--- a/service/src/main/java/uk/gov/mca/beacons/api/beaconsearch/rest/BeaconSearchSpecification.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/beaconsearch/rest/BeaconSearchSpecification.java
@@ -22,7 +22,7 @@ public class BeaconSearchSpecification {
   public static @Nullable Specification<BeaconSearchEntity> hasUses(
     String uses
   ) {
-    return hasFuzzySearchCriteria(uses, "useActivities");
+    return (root, query, cb) -> cb.equal(root.get("useActivities"), uses);
   }
 
   public static @Nullable Specification<BeaconSearchEntity> hasHexId(

--- a/service/src/main/java/uk/gov/mca/beacons/api/beaconsearch/rest/BeaconSearchSpecification.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/beaconsearch/rest/BeaconSearchSpecification.java
@@ -16,7 +16,12 @@ public class BeaconSearchSpecification {
   public static @Nullable Specification<BeaconSearchEntity> hasStatus(
     String status
   ) {
-    return (root, query, cb) -> cb.equal(root.get("beaconStatus"), status);
+    if (StringUtils.hasText(status)) {
+      return (root, query, cb) -> cb.equal(root.get("beaconStatus"), status);
+    } else {
+      return (root, query, cb) ->
+        likeLower(cb, root.get("beaconStatus"), status);
+    }
   }
 
   public static @Nullable Specification<BeaconSearchEntity> hasUses(

--- a/service/src/main/java/uk/gov/mca/beacons/api/beaconsearch/rest/BeaconSearchSpecification.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/beaconsearch/rest/BeaconSearchSpecification.java
@@ -16,13 +16,13 @@ public class BeaconSearchSpecification {
   public static @Nullable Specification<BeaconSearchEntity> hasStatus(
     String status
   ) {
-    return hasFuzzySearchCriteria(status, "beaconStatus");
+    return (root, query, cb) -> cb.equal(root.get("beaconStatus"), status);
   }
 
   public static @Nullable Specification<BeaconSearchEntity> hasUses(
     String uses
   ) {
-    return (root, query, cb) -> cb.equal(root.get("useActivities"), uses);
+    return hasFuzzySearchCriteria(uses, "useActivities");
   }
 
   public static @Nullable Specification<BeaconSearchEntity> hasHexId(

--- a/service/src/test/java/uk/gov/mca/beacons/api/beaconsearch/rest/BeaconSearchControllerIntegrationTest.java
+++ b/service/src/test/java/uk/gov/mca/beacons/api/beaconsearch/rest/BeaconSearchControllerIntegrationTest.java
@@ -30,7 +30,7 @@ class BeaconSearchControllerIntegrationTest extends WebIntegrationTest {
           .uri(uriBuilder ->
             uriBuilder
               .path(Endpoints.BeaconSearch.value + "/find-all")
-              .queryParam("status", "migrated")
+              .queryParam("status", "MIGRATED")
               .queryParam("uses", "maritime")
               .queryParam("hexId", randomHexId)
               .queryParam("ownerName", "")
@@ -61,7 +61,7 @@ class BeaconSearchControllerIntegrationTest extends WebIntegrationTest {
           .uri(uriBuilder ->
             uriBuilder
               .path(Endpoints.BeaconSearch.value + "/find-all")
-              .queryParam("status", "new")
+              .queryParam("status", "NEW")
               .queryParam("uses", "fishing vessel")
               .queryParam("hexId", randomHexId)
               .queryParam("ownerName", "")


### PR DESCRIPTION
## Context

Still experiencing some slowness with staging. Changing `status` param to not use fuzzy search to improve speed and the use of indexing.
