### PR TITLE
fix: update the path for assets due to vite update

### DIFF
--- a/backoffice/src/views/exports/letters/CoverLetter.tsx
+++ b/backoffice/src/views/exports/letters/CoverLetter.tsx
@@ -174,7 +174,10 @@ const LetterFooter: FunctionComponent = (): JSX.Element => {
     <div className="footer full">
       <div className="text"></div>
       <img
-        src="/assets/letter/Investors-in-People-Silver.png"
+        src={
+          import.meta.env.BASE_URL +
+          "/assets/letter/Investors-in-People-Silver.png"
+        }
         alt="Investors in People silver logo"
         className="investors-in-people-logo"
       />


### PR DESCRIPTION
This logo is missing in dev, staging and prod due to vite update. Updating path to resolve the issue.

Dev
![image](https://github.com/user-attachments/assets/454c64e9-8f3d-4b9b-9e80-874d1d1b813a)

Local
![image](https://github.com/user-attachments/assets/5c641960-edb5-49d1-879a-99bc4d028415)

