### PR TITLE
updating the redisdraftregistrationgateway to use modern redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       VITE_APP_FEEDBACK_EMAIL_ADDRESSES: "x@y.com,y@z.com"
 
   redis:
-    image: redis:6
+    image: redis:8
     ports:
       - "6379:6379"
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -10,13 +10,11 @@
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^1.3.0",
-        "@types/ioredis": "^4.26.7",
         "@types/jest": "^29.0.0",
         "axios": "^0.21.1",
         "cookie": "^1.0.2",
         "google-libphonenumber": "3.2.32",
         "govuk-frontend": "^4.10.0",
-        "ioredis": "^4.27.3",
         "isodate": "^0.1.4",
         "jest": "^27.2.0",
         "lodash": "^4.17.21",
@@ -26,7 +24,7 @@
         "notifications-node-client": "^5.1.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "redis-json": "^6.0.3",
+        "redis": "^5.5.6",
         "urlencoded-body-parser": "^3.0.0",
         "uuid": "^8.3.2",
         "winston": "^3.3.3"
@@ -923,12 +921,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@ioredis/commands": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
-      "license": "MIT"
-    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1681,6 +1673,230 @@
         }
       }
     },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-redis"
+      }
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/typeorm": {
+      "version": "0.2.45",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
+      "integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sqltools/formatter": "^1.2.2",
+        "app-root-path": "^3.0.0",
+        "buffer": "^6.0.3",
+        "chalk": "^4.1.0",
+        "cli-highlight": "^2.1.11",
+        "debug": "^4.3.1",
+        "dotenv": "^8.2.0",
+        "glob": "^7.1.6",
+        "js-yaml": "^4.0.0",
+        "mkdirp": "^1.0.4",
+        "reflect-metadata": "^0.1.13",
+        "sha.js": "^2.4.11",
+        "tslib": "^2.1.0",
+        "uuid": "^8.3.2",
+        "xml2js": "^0.4.23",
+        "yargs": "^17.0.1",
+        "zen-observable-ts": "^1.0.0"
+      },
+      "bin": {
+        "typeorm": "cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/typeorm"
+      },
+      "peerDependencies": {
+        "@sap/hana-client": "^2.11.14",
+        "better-sqlite3": "^7.1.2",
+        "hdb-pool": "^0.1.6",
+        "ioredis": "^4.28.3",
+        "mongodb": "^3.6.0",
+        "mssql": "^6.3.1",
+        "mysql2": "^2.2.5",
+        "oracledb": "^5.1.0",
+        "pg": "^8.5.1",
+        "pg-native": "^3.0.0",
+        "pg-query-stream": "^4.0.0",
+        "redis": "^3.1.1",
+        "sql.js": "^1.4.0",
+        "sqlite3": "^5.0.2",
+        "typeorm-aurora-data-api-driver": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sap/hana-client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "hdb-pool": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mssql": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-native": {
+          "optional": true
+        },
+        "pg-query-stream": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "typeorm-aurora-data-api-driver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@next-auth/typeorm-legacy-adapter/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@next/env": {
       "version": "12.3.5",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.5.tgz",
@@ -2188,6 +2404,66 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/@redis/bloom": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.5.6.tgz",
+      "integrity": "sha512-bNR3mxkwtfuCxNOzfV8B3R5zA1LiN57EH6zK4jVBIgzMzliNuReZXBFGnXvsi80/SYohajn78YdpYI+XNpqL+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.5.6.tgz",
+      "integrity": "sha512-M3Svdwt6oSfyfQdqEr0L2HOJH2vK7GgCFx1NfAQvpWAT4+ljoT1L5S5cKT3dA9NJrxrOPDkdoTPWJnIrGCOcmw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.5.6.tgz",
+      "integrity": "sha512-AIsoe3SsGQagqAmSQHaqxEinm5oCWr7zxPWL90kKaEdLJ+zw8KBznf2i9oK0WUFP5pFssSQUXqnscQKe2amfDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.5.6.tgz",
+      "integrity": "sha512-JSqasYqO0mVcHL7oxvbySRBBZYRYhFl3W7f0Da7BW8M/r0Z9wCiVrdjnN4/mKBpWZkoJT/iuisLUdPGhpKxBew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.5.6.tgz",
+      "integrity": "sha512-jkpcgq3NOI3TX7xEAJ3JgesJTxAx7k0m6lNxNsYdEM8KOl+xj7GaB/0CbLkoricZDmFSEAz7ClA1iK9XkGHf+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2415,15 +2691,6 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/ioredis": {
-      "version": "4.28.10",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
-      "integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4483,6 +4750,8 @@
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
       "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6502,32 +6771,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/ioredis": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.30.0.tgz",
-      "integrity": "sha512-P9F4Eo6zicYsIJbEy/mPJmSxKY0rVcmiy5H8oXPxPDotQRCvCBjBuI5QWoQQanVE9jdeocnum5iqYAHl4pHdLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "^1.0.2",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.1",
-        "denque": "^1.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isarguments": "^3.1.0",
-        "p-map": "^2.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/is-array-buffer": {
@@ -9384,28 +9627,10 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -10652,15 +10877,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -11381,22 +11597,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.5.6.tgz",
+      "integrity": "sha512-hbpqBfcuhWHOS9YLNcXcJ4akNr7HFX61Dq3JuFZ9S7uU7C7kvnzuH2PDIXOP62A3eevvACoG8UacuXP3N07xdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.5.6",
+        "@redis/client": "5.5.6",
+        "@redis/json": "5.5.6",
+        "@redis/search": "5.5.6",
+        "@redis/time-series": "5.5.6"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/redis-json": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/redis-json/-/redis-json-6.0.3.tgz",
-      "integrity": "sha512-m3F9WZ/LhESHEpagSyW4oqmfja0bdW6W52wQJm4FHj8gA0b+f5sdlp9BIa6q5+XGDqX6y6wS9WcsEJhhvyLeSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/redis-parser": {
@@ -11404,6 +11637,8 @@
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -12143,12 +12378,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/standard-as-callback": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -12951,209 +13180,6 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typeorm": {
-      "version": "0.2.45",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
-      "integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
-        "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
-        "cli-highlight": "^2.1.11",
-        "debug": "^4.3.1",
-        "dotenv": "^8.2.0",
-        "glob": "^7.1.6",
-        "js-yaml": "^4.0.0",
-        "mkdirp": "^1.0.4",
-        "reflect-metadata": "^0.1.13",
-        "sha.js": "^2.4.11",
-        "tslib": "^2.1.0",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23",
-        "yargs": "^17.0.1",
-        "zen-observable-ts": "^1.0.0"
-      },
-      "bin": {
-        "typeorm": "cli.js"
-      },
-      "funding": {
-        "url": "https://opencollective.com/typeorm"
-      },
-      "peerDependencies": {
-        "@sap/hana-client": "^2.11.14",
-        "better-sqlite3": "^7.1.2",
-        "hdb-pool": "^0.1.6",
-        "ioredis": "^4.28.3",
-        "mongodb": "^3.6.0",
-        "mssql": "^6.3.1",
-        "mysql2": "^2.2.5",
-        "oracledb": "^5.1.0",
-        "pg": "^8.5.1",
-        "pg-native": "^3.0.0",
-        "pg-query-stream": "^4.0.0",
-        "redis": "^3.1.1",
-        "sql.js": "^1.4.0",
-        "sqlite3": "^5.0.2",
-        "typeorm-aurora-data-api-driver": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@sap/hana-client": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "hdb-pool": {
-          "optional": true
-        },
-        "ioredis": {
-          "optional": true
-        },
-        "mongodb": {
-          "optional": true
-        },
-        "mssql": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "oracledb": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "pg-native": {
-          "optional": true
-        },
-        "pg-query-stream": {
-          "optional": true
-        },
-        "redis": {
-          "optional": true
-        },
-        "sql.js": {
-          "optional": true
-        },
-        "sqlite3": {
-          "optional": true
-        },
-        "typeorm-aurora-data-api-driver": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typeorm/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/typeorm/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/typeorm/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/typeorm/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/typeorm/node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/typeorm/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/typeorm/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/typescript": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -25,13 +25,11 @@
   },
   "dependencies": {
     "@azure/msal-node": "^1.3.0",
-    "@types/ioredis": "^4.26.7",
     "@types/jest": "^29.0.0",
     "axios": "^0.21.1",
     "cookie": "^1.0.2",
     "google-libphonenumber": "3.2.32",
     "govuk-frontend": "^4.10.0",
-    "ioredis": "^4.27.3",
     "isodate": "^0.1.4",
     "jest": "^27.2.0",
     "lodash": "^4.17.21",
@@ -41,7 +39,7 @@
     "notifications-node-client": "^5.1.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "redis-json": "^6.0.3",
+    "redis": "^5.5.6",
     "urlencoded-body-parser": "^3.0.0",
     "uuid": "^8.3.2",
     "winston": "^3.3.3"

--- a/webapp/src/entities/DraftRegistration.ts
+++ b/webapp/src/entities/DraftRegistration.ts
@@ -3,5 +3,6 @@ import { DraftBeaconUse } from "./DraftBeaconUse";
 import { Registration } from "./Registration";
 
 export interface DraftRegistration extends RecursivePartial<Registration> {
+  [key: string]: DraftBeaconUse[] | string | boolean;
   uses: DraftBeaconUse[];
 }

--- a/webapp/src/gateways/RedisDraftRegistrationGateway.ts
+++ b/webapp/src/gateways/RedisDraftRegistrationGateway.ts
@@ -1,14 +1,42 @@
-import Redis from "ioredis";
-import JSONCache from "redis-json";
+import { createClient, RedisClientType } from "redis";
 import { DraftRegistration } from "../entities/DraftRegistration";
 import { DraftRegistrationGateway } from "./interfaces/DraftRegistrationGateway";
 import { isValidUse } from "../lib/helpers/isValidUse";
+import logger from "../logger";
 
 export class RedisDraftRegistrationGateway implements DraftRegistrationGateway {
-  private cache = new JSONCache<DraftRegistration>(
-    new Redis(process.env.REDIS_URI),
-  );
   private static instance: DraftRegistrationGateway;
+  private cache: RedisClientType;
+
+  constructor() {
+    this.cache = createClient({ url: process.env.REDIS_URI });
+
+    this.cache.on("error", (err) => {
+      logger.error("Redis error:", err);
+    });
+
+    this.connect().catch((err) => {
+      logger.crit("Redis failed to connect on startup:", err);
+    });
+  }
+
+  private async connect(): Promise<void> {
+    if (!this.cache.isOpen) {
+      await this.cache.connect();
+      logger.debug("Redis connected");
+    }
+  }
+
+  public async disconnect(): Promise<void> {
+    try {
+      if (this.cache.isOpen) {
+        await this.cache.quit();
+        logger.debug("Redis disconnected");
+      }
+    } catch (err) {
+      console.error("Error disconnecting Redis:", err);
+    }
+  }
 
   static getGateway(): DraftRegistrationGateway {
     if (!RedisDraftRegistrationGateway.instance) {
@@ -20,18 +48,18 @@ export class RedisDraftRegistrationGateway implements DraftRegistrationGateway {
   }
 
   public async read(id: string): Promise<DraftRegistration> {
-    return (await this.cache.get(id)) as DraftRegistration;
+    return (await this.cache.json.get(id)) as DraftRegistration;
   }
 
   public async update(
     id: string,
     draftRegistration: DraftRegistration,
   ): Promise<void> {
-    await this.cache.set(id, draftRegistration);
+    await this.cache.json.set(id, "$", draftRegistration);
   }
 
   public async delete(id: string): Promise<void> {
-    await this.cache.del(id);
+    await this.cache.json.del(id);
   }
 
   public async createEmptyUse(submissionId: string): Promise<void> {


### PR DESCRIPTION
utilising redis JSON commands rather than the intermediate redis-json node wrapper

## Context

During the review of the MCA beacons web application node modules we found a module [redis-json](https://github.com/AkashBabu/redis-json). This is used as a wrapper to store JSON in redis, helping the developer by taking away the conversion of an object to a flattened string and keeping information about the type intact. It stores the data in redis hashsets which is a valid, older approach to handling JSON objects in redis.
The redis-json node module is now archived and no longer under active development. Redis supports storing data as JSON using the Redis-JSON module which has been available for some time and comes natively with redis version 8.
The beacons web application uses storage of draft registration objects in redis for users and in turn leans on redis-json to enable this.

## Changes in this pull request

a re-work of the redisDraftRegistrationGateway to utilise redisJSON commands
move to redis 8 in local dev
*previous draft registrations in redis will become invalid after this change*

## Things to check

- [ ] The redis in staging/production can use JSON commands. See: (https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/json-gs.html)
- [ ] Amount of active or in-flight draft registrations in redis and the impact switching may have
