### PR TITLE
Fix: Increase the time in seconds that the connection is allowed to be idle.

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -2,6 +2,7 @@ resource "aws_alb" "main" {
   name            = "${terraform.workspace}-beacons"
   subnets         = aws_subnet.public.*.id
   security_groups = [aws_security_group.lb.id]
+  idle_timeout    = 120
 
   access_logs {
     bucket  = aws_s3_bucket.logs.bucket


### PR DESCRIPTION
## Context

The default idle time for application load balancer in 60s, we need to increase this as we have slow response time with large number of records in staging. 

![image](https://github.com/user-attachments/assets/289d9011-7e45-4c0d-be29-6f893e391fcb)

