### PR TITLE
test: Add signing in and out to the manual smoke test instructions

### DIFF
--- a/tests/post-release-testing-scenarios.md
+++ b/tests/post-release-testing-scenarios.md
@@ -14,11 +14,24 @@ Instead, post a message on the "#maritime-and-coastguard-agency" Slack channel a
 
 ## Checklist
 
+### Deployment
+
 - [ ] Only the newly deployed images of the application are running (check the [AWS Console](https://eu-west-2.console.aws.amazon.com/ecs/v2/clusters/production-mca-beacons-cluster/services?region=eu-west-2))
+
+### Public facing
+
+Use the credentials for "Test B2C account" in 1 password to log into the public facing service.
+
 - [ ] As the test AccountHolder of the Beacon with HexId 1D0E9B07CEFFBFF, I can sign in to my account at
       https://register-406-beacons.service.gov.uk/
 - [ ] As an AccountHolder, I can see Beacon with HexId 1D0E9B07CEFFBFF in my account home
+- [ ] As an AccountHolder, I can sign out
+
+### Backoffice
+
+- [ ] As a BackofficeUser, I sign in to the Backoffice
 - [ ] As a BackofficeUser, I check if I can see a list of Beacons in default search mode
 - [ ] As a BackofficeUser, I check if I can see a list of Beacons in advanced search mode
 - [ ] As a BackofficeUser, I can search for the Beacon with HexID 1D0E9B07CEFFBFF
 - [ ] As a BackofficeUser, I can view the details of the Beacon with HexID 1D0E9B07CEFFBFF
+- [ ] As a BackofficeUser, I can sign out

--- a/tests/pre-release-testing-scenarios.md
+++ b/tests/pre-release-testing-scenarios.md
@@ -8,13 +8,26 @@ production release.
 
 ## Checklist
 
-Example beacon ID `1D0E9B07CEFFBFF`.
+### Deployment
 
 - [ ] Only the newly deployed images of the application are running (check the [AWS Console](https://eu-west-2.console.aws.amazon.com/ecs/v2/clusters/staging-mca-beacons-cluster/services?region=eu-west-2))
+
+### Public facing
+
+For staging, use the credentials for "Test B2C account" in 1 password to sign in.
+
+Example beacon ID `1D0E9B07CEFFBFF`.
+
 - [ ] As an AccountHolder, I can sign in to my account at https://dev.register-406-beacons.service.gov.uk/ or https://staging.register-406-beacons.service.gov.uk/
 - [ ] As an AccountHolder, I can register a new Beacon
 - [ ] As an AccountHolder, I can see the newly-registered Beacon in my account home
+- [ ] As an AccountHolder, I can sign out
+
+### Backoffice
+
+- [ ] As a BackofficeUser, I sign in to the Backoffice
 - [ ] As a BackofficeUser, I check if I can see a list of Beacons in default search mode
 - [ ] As a BackofficeUser, I check if I can see a list of Beacons in advanced search mode
 - [ ] As a BackofficeUser, I can search for the AccountHolder's newly-registered Beacon by HexID
 - [ ] As a BackofficeUser, I can view the details of the AccountHolder's newly-registered Beacon
+- [ ] As a BackofficeUser, I can sign out


### PR DESCRIPTION
## Context

To make the tests a little more thorough and more clearly sign post the user to use.
