### PR TITLE
fix: set draft registrations to expire after 6 hours

### DIFF
--- a/webapp/src/gateways/BeaconsApiBeaconGateway.ts
+++ b/webapp/src/gateways/BeaconsApiBeaconGateway.ts
@@ -5,6 +5,7 @@ import { DeprecatedRegistration } from "../lib/deprecatedRegistration/Deprecated
 import logger from "../logger";
 import { AuthGateway } from "./interfaces/AuthGateway";
 import { BeaconGateway } from "./interfaces/BeaconGateway";
+import { RedisDraftRegistrationGateway } from "./RedisDraftRegistrationGateway";
 
 export interface IDeleteBeaconRequest {
   beaconId: string;
@@ -37,6 +38,7 @@ export class BeaconsApiBeaconGateway implements BeaconGateway {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
       logger.info("Registration sent");
+      await this.scheduleDraftDeletion(draftRegistration);
       return true;
     } catch (error) {
       logger.error("sendRegistration:", error);
@@ -60,6 +62,7 @@ export class BeaconsApiBeaconGateway implements BeaconGateway {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
       logger.info("Registration updated");
+      await this.scheduleDraftDeletion(draftRegistration);
       return true;
     } catch (error) {
       logger.error("updateRegistration:", error);
@@ -93,6 +96,18 @@ export class BeaconsApiBeaconGateway implements BeaconGateway {
     return new DeprecatedRegistration(
       draftRegistration as Registration,
     ).serialiseToAPI();
+  }
+
+  private async scheduleDraftDeletion(draftRegistration: DraftRegistration) {
+    if (draftRegistration.id) {
+      setTimeout(async () => {
+        const redisGateway = new RedisDraftRegistrationGateway();
+        await redisGateway.delete(draftRegistration.id);
+        logger.info(
+          `Draft ${draftRegistration.id} scheduled for deletion after 6 hours`,
+        );
+      }, 21600000);
+    }
   }
 
   private async getAccessToken() {

--- a/webapp/src/useCases/getDraftRegistration.ts
+++ b/webapp/src/useCases/getDraftRegistration.ts
@@ -3,5 +3,10 @@ import { IAppContainer } from "../lib/IAppContainer";
 
 export const getDraftRegistration =
   ({ draftRegistrationGateway }: IAppContainer) =>
-  async (id: string): Promise<DraftRegistration> =>
-    await draftRegistrationGateway.read(id);
+  async (id: string): Promise<DraftRegistration> => {
+    const draftRegistration = await draftRegistrationGateway.read(id);
+    return {
+      ...draftRegistration,
+      id: id,
+    };
+  };


### PR DESCRIPTION
Reason for this fix:
As per issue 39, there are some issues when users click on registrations where some details appear corrupted, or incorrect.
This issue has not been reproducible and only a few registrations are having this issue.

There is currently a temporary fix for this change, which is to remove the Redis listing for the affected records.

What this change does
Currently, Redis is being used to store draft registrations/edit to registrations. They are only used during initial submissions and during edits. Once a save has occurred, there is no longer a need for the draft listing in Redis. This change sets the Redis listing from the Redis cache to expire after 6 hours once the original submission/edit has been saved.

Considerations
The TTL means that if a user completes/edits a registration, and then submits it, they will be greeted with the "Beacon Registration Complete" page. From this point, they will only have 6 hours to click "Back" on their browser to view the registration they just submitted. This does _not_ however affect the user if they close out their window, and re-open to make further edits.