### PR TITLE
fix: pipeline failure caused by missing class definition

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation 'com.azure:azure-identity:1.+'
 
     runtimeOnly 'org.postgresql:postgresql:42.3.4'
+    runtimeOnly 'com.nimbusds:oauth2-oidc-sdk:11.28'
 
     // Ensures compatibility across architectures by conditionally including dependencies
     if (System.getProperty("os.name").toLowerCase().contains("mac")


### PR DESCRIPTION
## Context

We had some [failures](https://github.com/mcagov/beacons/actions/runs/17795288513/job/50583106903#step:7:1894) in pipelines with beacons registration api service (java based application). This is caused by a missing class definition. This seems to have happen recently as pipelines where [healthy](https://github.com/mcagov/beacons/actions/runs/17732305004/job/50385919925) on Monday. 
<img width="718" height="171" alt="image" src="https://github.com/user-attachments/assets/b72295b9-6793-498f-a4e4-46aebace6c63" />
