### PR TITLE
fix: convert date to friendly format for notes

### DIFF
--- a/backoffice/src/panels/notesPanel/NotesViewing.test.tsx
+++ b/backoffice/src/panels/notesPanel/NotesViewing.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { INote } from "../../entities/INote";
 import { notesFixture } from "../../fixtures/notes.fixture";
-import { formatMonth } from "../../utils/dateTime";
+import { formatDateLong } from "../../utils/dateTime";
 import { noNotesMessage, NotesViewing } from "./NotesViewing";
 
 describe("NotesViewing", () => {
@@ -10,7 +10,7 @@ describe("NotesViewing", () => {
 
     for (const note of notesFixture) {
       expect(
-        await screen.findAllByText(formatMonth(note.createdDate)),
+        await screen.findAllByText(formatDateLong(note.createdDate)),
       ).toBeTruthy();
       expect(await screen.findByText(new RegExp(note.type, "i"))).toBeTruthy();
       expect(await screen.findByText(note.text)).toBeTruthy();

--- a/backoffice/src/panels/notesPanel/NotesViewing.tsx
+++ b/backoffice/src/panels/notesPanel/NotesViewing.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { INote } from "entities/INote";
 import React, { FunctionComponent } from "react";
-import { formatMonth } from "utils/dateTime";
+import { formatDateLong } from "utils/dateTime";
 import { titleCase } from "utils/writingStyle";
 
 interface INotesViewingProps {
@@ -41,7 +41,7 @@ export const NotesViewing: FunctionComponent<INotesViewingProps> = ({
           <TableBody>
             {notes.map((note) => (
               <TableRow key={note.id}>
-                <TableCell>{formatMonth(note.createdDate)}</TableCell>
+                <TableCell>{formatDateLong(note.createdDate)}</TableCell>
                 <TableCell>{titleCase(note.type)}</TableCell>
                 <TableCell>{note.text}</TableCell>
                 <TableCell>{note.fullName}</TableCell>


### PR DESCRIPTION
## Context

### Before 
<img width="618" height="183" alt="image" src="https://github.com/user-attachments/assets/84693959-09cf-4c0b-8814-8ba791c71068" />

### After
<img width="617" height="190" alt="image" src="https://github.com/user-attachments/assets/4b09a8d6-3fac-41de-9fc7-e6d6942c45a9" />