### PR TITLE
fix: add styles after sanitation.

### DIFF
--- a/maintenance-page/html/index.html
+++ b/maintenance-page/html/index.html
@@ -54,6 +54,8 @@
     <link
       rel="stylesheet"
       href="https://mca-beacons-b2c-assets.s3.eu-west-2.amazonaws.com/main-rebranded.css"
+      data-preload="true"
+      type="text/css"
     />
   </head>
   <body class="govuk-template__body">

--- a/webapp/public/auth/login.html
+++ b/webapp/public/auth/login.html
@@ -52,8 +52,23 @@
     <link
       rel="stylesheet"
       href="https://mca-beacons-b2c-assets.s3.eu-west-2.amazonaws.com/main-rebranded.css"
+      type="text/css"
       data-preload="true"
     />
+    <script>
+      const observer = new MutationObserver((mutationsList, observer) => {
+        if (document.getElementById("api")) {
+          document.documentElement.classList.remove(
+            "govuk-template--rebranded",
+          );
+          document.body.classList.remove("govuk-template__body");
+          document.documentElement.classList.add("govuk-template--rebranded");
+          document.body.classList.add("govuk-template__body");
+          observer.disconnect();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    </script>
   </head>
   <body class="govuk-template__body">
     <header class="govuk-header" role="banner" data-module="govuk-header">

--- a/webapp/public/auth/new-password.html
+++ b/webapp/public/auth/new-password.html
@@ -63,7 +63,22 @@
       rel="stylesheet"
       href="https://mca-beacons-b2c-assets.s3.eu-west-2.amazonaws.com/main-rebranded.css"
       data-preload="true"
+      type="text/css"
     />
+    <script>
+      const observer = new MutationObserver((mutationsList, observer) => {
+        if (document.getElementById("api")) {
+          document.documentElement.classList.remove(
+            "govuk-template--rebranded",
+          );
+          document.body.classList.remove("govuk-template__body");
+          document.documentElement.classList.add("govuk-template--rebranded");
+          document.body.classList.add("govuk-template__body");
+          observer.disconnect();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    </script>
   </head>
   <body class="govuk-template__body">
     <header class="govuk-header" role="banner" data-module="govuk-header">

--- a/webapp/public/auth/reset-password.html
+++ b/webapp/public/auth/reset-password.html
@@ -55,7 +55,22 @@
       rel="stylesheet"
       href="https://mca-beacons-b2c-assets.s3.eu-west-2.amazonaws.com/main-rebranded.css"
       data-preload="true"
+      type="text/css"
     />
+    <script>
+      const observer = new MutationObserver((mutationsList, observer) => {
+        if (document.getElementById("api")) {
+          document.documentElement.classList.remove(
+            "govuk-template--rebranded",
+          );
+          document.body.classList.remove("govuk-template__body");
+          document.documentElement.classList.add("govuk-template--rebranded");
+          document.body.classList.add("govuk-template__body");
+          observer.disconnect();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    </script>
   </head>
   <body class="govuk-template__body">
     <header class="govuk-header" role="banner" data-module="govuk-header">

--- a/webapp/public/auth/signup.html
+++ b/webapp/public/auth/signup.html
@@ -54,7 +54,22 @@
       rel="stylesheet"
       href="https://mca-beacons-b2c-assets.s3.eu-west-2.amazonaws.com/main-rebranded.css"
       data-preload="true"
+      type="text/css"
     />
+    <script>
+      const observer = new MutationObserver((mutationsList, observer) => {
+        if (document.getElementById("api")) {
+          document.documentElement.classList.remove(
+            "govuk-template--rebranded",
+          );
+          document.body.classList.remove("govuk-template__body");
+          document.documentElement.classList.add("govuk-template--rebranded");
+          document.body.classList.add("govuk-template__body");
+          observer.disconnect();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    </script>
   </head>
   <body class="govuk-template__body">
     <header class="govuk-header" role="banner" data-module="govuk-header">

--- a/webapp/public/servicedown/service-down.html
+++ b/webapp/public/servicedown/service-down.html
@@ -53,6 +53,8 @@
     <link
       rel="stylesheet"
       href="https://mca-beacons-b2c-assets.s3.eu-west-2.amazonaws.com/main-rebranded.css"
+      data-preload="true"
+      type="text/css"
     />
   </head>
   <body class="govuk-template__body">


### PR DESCRIPTION
## Context

Azure AD B2C user flows which appears to removes styles as part of a security measure i.e sanitation. This fix is to add them back.

<img width="643" height="159" alt="image" src="https://github.com/user-attachments/assets/e8907f32-fa5d-4137-a644-573f17d47011" />


