### PR TITLE
fix: redirect to your account home page if submission cookie is not set.

### DIFF
--- a/webapp/src/router/rules/GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage.ts
+++ b/webapp/src/router/rules/GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage.ts
@@ -3,7 +3,7 @@ import { DraftRegistration } from "../../entities/DraftRegistration";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { redirectUserTo } from "../../lib/redirectUserTo";
 import { formSubmissionCookieId } from "../../lib/types";
-import { GeneralPageURLs } from "../../lib/urls";
+import { AccountPageURLs } from "../../lib/urls";
 import { Rule } from "./Rule";
 
 export class GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage
@@ -24,7 +24,7 @@ export class GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_
 
   public async action(): Promise<GetServerSidePropsResult<any>> {
     if (this.draftRegistrationCookieIdIsMissing())
-      return redirectUserTo(GeneralPageURLs.start);
+      return redirectUserTo(AccountPageURLs.accountHome);
 
     await this.createBlankDraftRegistration();
 

--- a/webapp/test/router/rules/GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage.test.ts
+++ b/webapp/test/router/rules/GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage.test.ts
@@ -3,7 +3,6 @@ import { GetServerSidePropsResult } from "next";
 import { DraftRegistration } from "../../../src/entities/DraftRegistration";
 import { IAppContainer } from "../../../src/lib/IAppContainer";
 import { formSubmissionCookieId } from "../../../src/lib/types";
-import { GeneralPageURLs } from "../../../src/lib/urls";
 import { GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage } from "../../../src/router/rules/GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage";
 
 describe("GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage", () => {
@@ -98,7 +97,7 @@ describe("GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_The
 
       expect(result).toMatchObject({
         redirect: {
-          destination: GeneralPageURLs.start,
+          destination: "/account/your-beacon-registry-account",
         },
       });
     });


### PR DESCRIPTION
## Context

Redirect to your beacon account home page if submission cookie is not set.
