### PR TITLE
feat: add TTL to Redis draft registration keys

### DIFF
--- a/webapp/src/gateways/RedisDraftRegistrationGateway.ts
+++ b/webapp/src/gateways/RedisDraftRegistrationGateway.ts
@@ -9,6 +9,9 @@ export class RedisDraftRegistrationGateway implements DraftRegistrationGateway {
     new Redis(process.env.REDIS_URI),
   );
   private static instance: DraftRegistrationGateway;
+  private static readonly TTL_SECONDS = parseInt(
+    process.env.DRAFT_REGISTRATION_TTL_SECONDS || "2592000",
+  );
 
   static getGateway(): DraftRegistrationGateway {
     if (!RedisDraftRegistrationGateway.instance) {
@@ -28,6 +31,10 @@ export class RedisDraftRegistrationGateway implements DraftRegistrationGateway {
     draftRegistration: DraftRegistration,
   ): Promise<void> {
     await this.cache.set(id, draftRegistration);
+    await this.cache.redis.expire(
+      id,
+      RedisDraftRegistrationGateway.TTL_SECONDS,
+    );
   }
 
   public async delete(id: string): Promise<void> {


### PR DESCRIPTION
This is a change following the router ruling changes made by @asvegah to delete registrations keys which have been edited/deleted.

If a user starts a registration, and never comes back, there is no expiration on the keys - meaning the key could rest in Redis indefinitely. 

This change sets an expiration on all keys created in the Beacons Redis gateway. 

The TTL is managed in the .env.local file but defaults to a week (as discussed).
