### PR TITLE
feat: add ttl expiration to all redis key operations

### DIFF
--- a/webapp/src/gateways/RedisDraftRegistrationGateway.ts
+++ b/webapp/src/gateways/RedisDraftRegistrationGateway.ts
@@ -10,7 +10,7 @@ export class RedisDraftRegistrationGateway implements DraftRegistrationGateway {
   );
   private static instance: DraftRegistrationGateway;
   private static readonly TTL_SECONDS = parseInt(
-    process.env.DRAFT_REGISTRATION_TTL_SECONDS || "604800",
+    process.env.DRAFT_REGISTRATION_TTL_SECONDS || "2628000",
   );
 
   static getGateway(): DraftRegistrationGateway {


### PR DESCRIPTION
This change is to add a TTL to all Redis key updates of a week (as discussed). 

This will ensure that there are no keys in the Redis cache indefinitely. 

This uses the environment variable DRAFT_REGISTRATION_TTL_SECONDS - If not set, it will default to a week. 

There is no current configuration to set expiry on keys, meaning if a user creates a registration, quits mid-registration and never comes back on the same browser/clears their cookies, the key remains. 