### PR TITLE
docs: added integration test user information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Application specific tests are covered in the READMEs linked to above.
 
 If you are working towards a release, look at the [end-to-end and smoke test documentation](./tests/README.md).
 
+Known issues and resolution for Unit, Integration and End-to-end testing are documented in the [tests README.md file](./tests/README.md).
+
 ## Architecture
 
 ![Architecture diagram](docs/architecture_diagram.svg)

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,15 @@ $ npm run test:e2e
 - Automated end-to-end tests require the `SESSION_TOKEN`, and may fail unexpectedly, due to rotating session tokens. To resolve this, log into local/dev/staging webapp using the test account. Locate the session token in dev tools: Application -> cookies -> \_\_Secure-next-auth.session-token -> value.
 - Copy this value and update the corresponding secret in the GitHub repository.
 
+## Integration testing
+
+As part of our integration tests, a test user "test@test.com" is created in the Azure TEST tenancy. As a part of these tests, this user should be automatically deleted.
+In the event that the test user is not deleted, the integration tests can fail:
+
+- "Another object with the same value for property proxyAddresses already exists."
+
+In order to remediate this failure, the "test@test.com" user will need to be deleted from the test tenancy. The tests should then succeed.
+
 ## Smoke testing
 
 The smoke tests are currently manual. We are looking to automate these.


### PR DESCRIPTION
## Context

Following failure of integration tests, it was found that the test user deletion step can be missed (tests cancelled mid-way through). After the deletion of this user is missed, all integration tests fail, requiring "test@test.com" to be deleted from the test tenancy. This pull request is to document these steps.

## Changes in this pull request

Documentation change.

## Guidance to review

Read the Beacons runbook, ensure all information is concise and accurate.

## Link to Trello card

N/A

## Things to check

- [x] Environment variables have been updated
