### PR TITLE
feat: added preprod and production pipelines

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,47 @@
+name: Deploy a version to production
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Tag to deploy to production"
+        required: true
+        type: string
+
+jobs:
+  deploy_production:
+    name: Production
+    uses: ./.github/workflows/_reusable-deploy.yml
+    with:
+      environment: production
+      terraform_workspace: production
+      version: ${{ inputs.version }}
+      trello_list_id: 6157064b4d7e1b3b1ea839ad
+    secrets:
+      alert_email_address: ${{ secrets.ALERT_EMAIL_ADDRESS }}
+      alert_pagerduty_integration_url: ${{ secrets.ALERT_PAGERDUTY_INTEGRATION_URL }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      db_password: ${{ secrets.DB_PASSWORD }}
+      gov_notify_api_key: ${{ secrets.GOV_NOTIFY_API_KEY }}
+      webapp_azure_ad_client_secret: ${{ secrets.WEBAPP_CLIENT_SECRET }}
+      webapp_azure_b2c_client_secret: ${{ secrets.AZURE_B2C_CLIENT_SECRET }}
+      webapp_azure_b2c_next_auth_jwt_secret: ${{ secrets.JWT_SECRET }}
+      service_basic_auth_username: ${{ secrets.SERVICE_BASIC_AUTH_USERNAME }}
+      service_basic_auth_password: ${{ secrets.SERVICE_BASIC_AUTH_PASSWORD }}
+      aws_account_number: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+      trello_api_key: ${{ secrets.TRELLO_API_KEY }}
+      trello_board_email_address: ${{ secrets.TRELLO_BOARD_EMAIL_ADDRESS }}
+      trello_token: ${{ secrets.TRELLO_TOKEN }}
+      opensearch_master_user_name: ${{ secrets.OPENSEARCH_USERNAME }}
+      opensearch_master_user_password: ${{ secrets.OPENSEARCH_PASSWORD }}
+      opensearch_proxy_sso_client_id: ${{ secrets.OPENSEARCH_PROXY_SSO_CLIENT_ID }}
+      opensearch_proxy_sso_client_secret: ${{ secrets.OPENSEARCH_PROXY_SSO_CLIENT_SECRET }}
+      microsoft_graph_client_id: ${{ secrets.MICROSOFT_GRAPH_CLIENT_ID }}
+      microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}
+      microsoft_graph_b2c_tenant_id: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_ID }}
+      microsoft_graph_b2c_tenant_name: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_NAME }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,111 @@
+name: Test then deploy a version to staging
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Tag to test and deploy to staging"
+        required: true
+        type: string
+
+jobs:
+  terraform_lint:
+    name: Terraform lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.0.0
+      - name: Terraform Lint
+        run: terraform fmt --recursive --check
+
+  prettier_check:
+    name: Prettier check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.17.0"
+      - name: Prettier check
+        run: |
+          npm ci
+          npm run format:check
+
+  test_webapp:
+    name: Test Webapp
+    uses: ./.github/workflows/_reusable-test-webapp.yml
+    with:
+      git-reference: ${{ inputs.version }}
+    secrets:
+      test_azure_b2c_session_token: ${{ secrets.TEST_WEBAPP_AZURE_B2C_SESSION_TOKEN }}
+      test_azure_b2c_jwt_secret: ${{ secrets.TEST_WEBAPP_AZURE_B2C_JWT_SECRET }}
+
+  test_service:
+    name: Test Service
+    uses: ./.github/workflows/_reusable-test-service.yml
+    with:
+      environment: staging
+      git-reference: ${{ inputs.version }}
+    secrets:
+      microsoft_graph_client_id: ${{ secrets.MICROSOFT_GRAPH_CLIENT_ID }}
+      microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}
+      microsoft_graph_b2c_tenant_id: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_ID }}
+      microsoft_graph_b2c_tenant_name: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_NAME }}
+
+  test_backoffice:
+    name: Test Backoffice
+    uses: ./.github/workflows/_reusable-test-backoffice.yml
+    with:
+      git-reference: ${{ inputs.version }}
+
+  deploy_staging:
+    name: Staging
+    needs:
+      - terraform_lint
+      - prettier_check
+      - test_webapp
+      - test_service
+      - test_backoffice
+    uses: ./.github/workflows/_reusable-deploy.yml
+    with:
+      environment: staging
+      terraform_workspace: staging
+      version: ${{ inputs.version }}
+      trello_list_id: 6157064b4d7e1b3b1ea839ad
+    secrets:
+      alert_email_address: ${{ secrets.ALERT_EMAIL_ADDRESS }}
+      alert_pagerduty_integration_url: ${{ secrets.ALERT_PAGERDUTY_INTEGRATION_URL }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      db_password: ${{ secrets.DB_PASSWORD }}
+      gov_notify_api_key: ${{ secrets.TEST_GOV_NOTIFY_API_KEY }}
+      webapp_azure_ad_client_secret: ${{ secrets.TEST_WEBAPP_AZURE_AD_CLIENT_SECRET }}
+      webapp_azure_b2c_client_secret: ${{ secrets.TEST_WEBAPP_AZURE_B2C_CLIENT_SECRET }}
+      webapp_azure_b2c_next_auth_jwt_secret: ${{ secrets.TEST_WEBAPP_AZURE_B2C_JWT_SECRET }}
+      service_basic_auth_username: ${{ secrets.SERVICE_BASIC_AUTH_USERNAME }}
+      service_basic_auth_password: ${{ secrets.SERVICE_BASIC_AUTH_PASSWORD }}
+      aws_account_number: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+      trello_api_key: ${{ secrets.TRELLO_API_KEY }}
+      trello_board_email_address: ${{ secrets.TRELLO_BOARD_EMAIL_ADDRESS }}
+      trello_token: ${{ secrets.TRELLO_TOKEN }}
+      opensearch_master_user_name: ${{ secrets.OPENSEARCH_USERNAME }}
+      opensearch_master_user_password: ${{ secrets.OPENSEARCH_PASSWORD }}
+      opensearch_proxy_sso_client_id: ${{ secrets.OPENSEARCH_PROXY_SSO_CLIENT_ID }}
+      opensearch_proxy_sso_client_secret: ${{ secrets.OPENSEARCH_PROXY_SSO_CLIENT_SECRET }}
+      microsoft_graph_client_id: ${{ secrets.MICROSOFT_GRAPH_CLIENT_ID }}
+      microsoft_graph_client_secret: ${{ secrets.MICROSOFT_GRAPH_CLIENT_SECRET }}
+      microsoft_graph_b2c_tenant_id: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_ID }}
+      microsoft_graph_b2c_tenant_name: ${{ secrets.MICROSOFT_GRAPH_B2C_TENANT_NAME }}


### PR DESCRIPTION
## Context

This is to facilitate the deployment of Beacons pre-production and production environments. Tests are ran on the pre-production deployments but not in production. These are within the github workflows and can be ran on command using a tag for the latest image.

## Guidance to review

Consider if testing in pre-production is necessary. 

The reason this came to be is because we can run previous production and pre-prod runs to deploy into the respective environments, however in the case that we no longer have access to the runs, we need a way to run them on-demand.

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [x] Environment variables have been updated
