### PR TITLE
fix: prevent saving a registration with no uses

### DIFF
--- a/service/src/main/java/uk/gov/mca/beacons/api/registration/rest/CreateRegistrationDTO.java
+++ b/service/src/main/java/uk/gov/mca/beacons/api/registration/rest/CreateRegistrationDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.List;
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import lombok.*;
 import uk.gov.mca.beacons.api.beacon.rest.CreateBeaconDTO;
 import uk.gov.mca.beacons.api.beaconowner.rest.CreateBeaconOwnerDTO;
@@ -22,6 +23,7 @@ public class CreateRegistrationDTO {
   private CreateBeaconDTO createBeaconDTO;
 
   @Valid
+  @NotEmpty
   @JsonProperty("uses")
   private List<CreateBeaconUseDTO> createBeaconUseDTOs;
 

--- a/service/src/test/java/uk/gov/mca/beacons/api/registration/rest/RegistrationControllerIntegrationTest.java
+++ b/service/src/test/java/uk/gov/mca/beacons/api/registration/rest/RegistrationControllerIntegrationTest.java
@@ -41,6 +41,23 @@ public class RegistrationControllerIntegrationTest extends WebIntegrationTest {
         .expectBody()
         .json(registrationBody);
     }
+
+    @Test
+    void shouldRejectRegistrationWithNoUses() throws Exception {
+      final String registrationBody = getRegistrationBody(
+        RegistrationUseCase.NO_USES,
+        accountHolderId
+      );
+
+      webTestClient
+        .post()
+        .uri(Endpoints.Registration.value + "/register")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(registrationBody)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+    }
   }
 
   @Nested
@@ -82,6 +99,23 @@ public class RegistrationControllerIntegrationTest extends WebIntegrationTest {
         .isOk()
         .expectBody()
         .json(updateRegistrationBody);
+    }
+
+    @Test
+    void shouldRejectUpdateWithNoUses() throws Exception {
+      final String updateRegistrationBody = getRegistrationBody(
+        RegistrationUseCase.NO_USES,
+        accountHolderId
+      );
+
+      webTestClient
+        .patch()
+        .uri(Endpoints.Registration.value + "/register/" + beaconId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(updateRegistrationBody)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
     }
   }
 

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
@@ -16,6 +16,8 @@ import { withSession } from "../../../../lib/middleware/withSession";
 import { redirectUserTo } from "../../../../lib/redirectUserTo";
 import { formSubmissionCookieId } from "../../../../lib/types";
 import { AccountPageURLs } from "../../../../lib/urls";
+import { Actions } from "../../../../lib/URLs/Actions";
+import { UrlBuilder } from "../../../../lib/URLs/UrlBuilder";
 import logger from "../../../../logger";
 import { WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError } from "../../../../router/rules/WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError";
 
@@ -87,6 +89,12 @@ export const getServerSideProps: GetServerSideProps = withSession(
     const submissionCookieId = context.req.cookies[formSubmissionCookieId];
     const draftRegistration: DraftRegistration =
       await getDraftRegistration(submissionCookieId);
+
+    if (!draftRegistration.uses || draftRegistration.uses.length === 0) {
+      return redirectUserTo(
+        UrlBuilder.buildUseSummaryUrl(Actions.update, draftRegistration.id),
+      );
+    }
 
     try {
       const result = await updateRegistration(

--- a/webapp/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
+++ b/webapp/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
@@ -90,6 +90,9 @@ export const getServerSideProps: GetServerSideProps = withSession(
     const draftRegistration: DraftRegistration =
       await getDraftRegistration(submissionCookieId);
 
+    if (!draftRegistration || !draftRegistration.id)
+      return redirectUserTo(AccountPageURLs.accountHome);
+
     if (!draftRegistration.uses || draftRegistration.uses.length === 0) {
       return redirectUserTo(
         UrlBuilder.buildUseSummaryUrl(Actions.update, draftRegistration.id),

--- a/webapp/test/pages/manage-my-registrations/complete.test.tsx
+++ b/webapp/test/pages/manage-my-registrations/complete.test.tsx
@@ -26,7 +26,7 @@ describe("CompletePage", () => {
       id: "draft-registration-id",
       hexId: "draft-registration-hexId",
       model: "ASOS",
-      uses: [],
+      uses: [{}],
     };
 
     const mockSessionGateway = {
@@ -69,6 +69,28 @@ describe("CompletePage", () => {
           destination: "/account/your-beacon-registry-account",
         },
       });
+    });
+
+    it("should redirect the user to uses section if the registration has no uses", async () => {
+      mockContainer.getDraftRegistration = jest
+        .fn()
+        .mockResolvedValue({ ...mockDraftRegistration, uses: [] });
+      const context = {
+        req: { cookies: { [formSubmissionCookieId]: "test-cookie-uuid" } },
+        res: createResponse(),
+        container: mockContainer,
+        session: { user: { authId: "a-session-id" } },
+      };
+
+      const result = await getServerSideProps(context as any);
+
+      expect(result).toMatchObject({
+        redirect: {
+          destination:
+            "/manage-my-registrations/draft-registration-id/update/uses/",
+        },
+      });
+      expect(mockUpdateRegistration).not.toHaveBeenCalled();
     });
 
     it("should attempt to update the user's registration", async () => {


### PR DESCRIPTION
## Context

This change has been made following an incident that has been raised where a user has been able to remove all uses from a Beacons submission. Once all the uses have been removed, and the edit has been submitted, it was submitted successfully. This change amends this behaviour so that the user is once again prompted to add a use to the registration.

This PR comes with relevant testing also.

## Changes in this pull request

I have added NotEmpty to the uses list so that the service api is able to check the uses as it should.

## Guidance to review

This has been tested locally. This will need to be tested in development and staging before being deployed to production, with sign off from MCA (as they have reproduced this in the staging environment before raising this request.

## Things to check

- [x] Environment variables have been updated
