### PR TITLE
fix: return not found for wordpress routes

### DIFF
--- a/webapp/src/router/BeaconsPageRouter.ts
+++ b/webapp/src/router/BeaconsPageRouter.ts
@@ -15,5 +15,7 @@ export class BeaconsPageRouter implements PageRouter {
         return await rule.action();
       }
     }
+
+    return { notFound: true };
   }
 }

--- a/webapp/test/pages/register-a-beacon/additional-beacon-use.test.tsx
+++ b/webapp/test/pages/register-a-beacon/additional-beacon-use.test.tsx
@@ -116,7 +116,7 @@ describe("AdditionalBeaconUse page", () => {
   });
 
   describe("getServerSideProps()", () => {
-    it("given a non-existent currentUseId, throws an error", async () => {
+    it("given a non-existent currentUseId, returns not found", async () => {
       const mockSessionGateway = {
         getSession: jest
           .fn()
@@ -145,7 +145,7 @@ describe("AdditionalBeaconUse page", () => {
 
       const result = await getServerSideProps(context as any);
 
-      expect(result).toBeUndefined();
+      expect(result).toEqual({ notFound: true });
     });
   });
 });

--- a/webapp/test/router/BeaconsPageRouter.test.ts
+++ b/webapp/test/router/BeaconsPageRouter.test.ts
@@ -1,0 +1,40 @@
+import { BeaconsPageRouter } from "../../src/router/BeaconsPageRouter";
+import { Rule } from "../../src/router/rules/Rule";
+
+describe("BeaconsPageRouter", () => {
+  const ruleThat = (matches: boolean, result: any = { props: {} }): Rule => ({
+    condition: jest.fn().mockResolvedValue(matches),
+    action: jest.fn().mockResolvedValue(result),
+  });
+
+  it("executes the action of the first rule whose condition is met", async () => {
+    const expected = { props: { showCookieBanner: true } };
+    const skipped = ruleThat(false);
+    const laterMatch = ruleThat(true, { props: { wrong: true } });
+
+    const result = await new BeaconsPageRouter([
+      skipped,
+      ruleThat(true, expected),
+      laterMatch,
+    ]).execute();
+
+    expect(result).toEqual(expected);
+    expect(skipped.action).not.toHaveBeenCalled();
+    expect(laterMatch.action).not.toHaveBeenCalled();
+  });
+
+  it("returns not found when no rule matches, rather than undefined", async () => {
+    const result = await new BeaconsPageRouter([
+      ruleThat(false),
+      ruleThat(false),
+    ]).execute();
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it("returns not found when there are no rules at all", async () => {
+    const result = await new BeaconsPageRouter([]).execute();
+
+    expect(result).toEqual({ notFound: true });
+  });
+});


### PR DESCRIPTION
## Context

We are getting paged for 5XX alerts on the beacons service where bots are hitting wordpress endpoints to check for vulnerabilities. This is to amend the functionality so that it returns 404s instead.

## Changes in this pull request

Added tests and not found functionality for these routes being tested.

## Guidance to review

Run the tests, run the app locally and test the endpoints.

## Things to check

- [x] Environment variables have been updated
- [ ] (For Dependabot Upgrades) - Checked for breaking changes
